### PR TITLE
pin-1864: New template version

### DIFF
--- a/src/main/resources/application-standalone.conf
+++ b/src/main/resources/application-standalone.conf
@@ -37,7 +37,7 @@ purpose-process {
     authorization-management = "http://localhost:8086/authorization-management/0.1"
     catalog-management       = "http://localhost:8087/catalog-management/0.1"
     party-management         = "http://localhost:8085/party-management/0.1"
-    purpose-management       = "http://localhost:8001/purpose-management/0.0"
+    purpose-management       = "http://localhost:8089/purpose-management/0.1"
   }
 }
 

--- a/src/main/resources/application-standalone.conf
+++ b/src/main/resources/application-standalone.conf
@@ -28,6 +28,7 @@ purpose-process {
     audience = ${ACCEPTED_AUDIENCES}
   }
   storage {
+    kind = "file"
     container = "container"
     risk-analysis-path = "target/risk-analysis/docs"
   }
@@ -36,7 +37,7 @@ purpose-process {
     authorization-management = "http://localhost:8086/authorization-management/0.1"
     catalog-management       = "http://localhost:8087/catalog-management/0.1"
     party-management         = "http://localhost:8085/party-management/0.1"
-    purpose-management       = "http://localhost:8089/purpose-management/0.1"
+    purpose-management       = "http://localhost:8001/purpose-management/0.0"
   }
 }
 

--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -837,100 +837,13 @@ components:
         version:
           type: string
         answers:
-          $ref: '#/components/schemas/RiskAnalysisFormAnswers'
+          additionalProperties:
+            type: array
+            items:
+              type: string
       required:
         - version
         - answers
-    RiskAnalysisFormAnswers:
-      type: object
-      properties:
-        purpose:
-          $ref: '#/components/schemas/RiskAnalysisFormTextAnswer'
-        usesPersonalData:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-        usesThirdPartyPersonalData:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-        usesConfidentialData:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-        securedDataAccess:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-        legalBasis:
-          type: array
-          items:
-            $ref: '#/components/schemas/FormLegalBasisAnswers'
-        legalObligationReference:
-          $ref: '#/components/schemas/RiskAnalysisFormTextAnswer'
-        publicInterestReference:
-          $ref: '#/components/schemas/RiskAnalysisFormTextAnswer'
-        knowsAccessedDataCategories:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-        accessDataArt9Gdpr:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-        accessUnderageData:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-        knowsDataQuantity:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-        dataQuantity:
-          $ref: '#/components/schemas/FormDataQuantityAnswers'
-        deliveryMethod:
-          $ref: '#/components/schemas/FormDeliveryMethodAnswers'
-        doneDpia:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-        definedDataRetentionPeriod:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-        purposePursuit:
-          $ref: '#/components/schemas/FormPurposePursuitAnswers'
-        checkedExistenceMereCorrectnessInteropCatalogue:
-          type: array
-          items:
-            $ref: '#/components/schemas/RiskAnalysisFormYesAnswer'
-        checkedAllDataNeeded:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-        checkedExistenceMinimalDataInteropCatalogue:
-          $ref: '#/components/schemas/RiskAnalysisFormYesNoAnswer'
-      required:
-        - purpose
-        - usesPersonalData
-    RiskAnalysisFormTextAnswer:
-      type: string
-    RiskAnalysisFormYesNoAnswer:
-      type: string
-      enum:
-        - 'YES'
-        - 'NO'
-    RiskAnalysisFormYesAnswer:
-      type: string
-      enum:
-        - 'YES'
-    FormLegalBasisAnswers:
-      type: string
-      enum:
-        - CONSENT
-        - CONTRACT
-        - LEGAL_OBLIGATION
-        - SAFEGUARD
-        - PUBLIC_INTEREST
-        - LEGITIMATE_INTEREST
-    FormDataQuantityAnswers:
-      type: string
-      enum:
-        - QUANTITY_0_TO_100
-        - QUANTITY_101_TO_500
-        - QUANTITY_500_TO_1000
-        - QUANTITY_1001_TO_5000
-        - QUANTITY_5001_OVER
-    FormDeliveryMethodAnswers:
-      type: string
-      enum:
-        - CLEARTEXT
-        - AGGREGATE
-        - ANONYMOUS
-        - PSEUDOANONYMOUS
-    FormPurposePursuitAnswers:
-      type: string
-      enum:
-        - MERE_CORRECTNESS
-        - NEW_PERSONAL_DATA
     Problem:
       properties:
         type:

--- a/src/main/resources/riskAnalysisTemplate/forms/1.0.json
+++ b/src/main/resources/riskAnalysisTemplate/forms/1.0.json
@@ -4,11 +4,20 @@
     {
       "id": "purpose",
       "type": "text",
+      "dataType": "freeText",
       "label": {
         "it": "Finalità (richiesto)",
         "en": "Purpose (required)"
       },
       "infoLabel": {
+        "it": "Indicare per quale finalità si intende accedere ai dati messi a disposizione con la fruizione del presente E-Service",
+        "en": "State what is your purpose in accessing the data provided with this E-Service"
+      },
+      "pdfLabel": {
+        "it": "Finalità (richiesto)",
+        "en": "Purpose (required)"
+      },
+      "pdfInfoLabel": {
         "it": "Indicare per quale finalità si intende accedere ai dati messi a disposizione con la fruizione del presente E-Service",
         "en": "State what is your purpose in accessing the data provided with this E-Service"
       },
@@ -19,17 +28,24 @@
     {
       "id": "usesPersonalData",
       "type": "radio",
+      "dataType": "single",
       "label": {
+        "it": "Indicare se si accede a dati personali (richiesto)",
+        "en": "Will you have access to personal data? (required)"
+      },
+      "pdfLabel": {
         "it": "Indicare se si accede a dati personali (richiesto)",
         "en": "Will you have access to personal data? (required)"
       },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -40,17 +56,24 @@
     {
       "id": "usesThirdPartyPersonalData",
       "type": "radio",
+      "dataType": "single",
       "label": {
+        "it": "Indicare se si accede a dati non personali di terzi (richiesto)",
+        "en": "Will you access third-party non personal data? (required)"
+      },
+      "pdfLabel": {
         "it": "Indicare se si accede a dati non personali di terzi (richiesto)",
         "en": "Will you access third-party non personal data? (required)"
       },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -66,17 +89,24 @@
     {
       "id": "usesConfidentialData",
       "type": "radio",
+      "dataType": "single",
       "label": {
+        "it": "Indicare se si accede a dati non personali ma confidenziali o strettamente riservati (richiesto)",
+        "en": "Will you access confidential or reserved non personal data? (required)"
+      },
+      "pdfLabel": {
         "it": "Indicare se si accede a dati non personali ma confidenziali o strettamente riservati (richiesto)",
         "en": "Will you access confidential or reserved non personal data? (required)"
       },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -96,6 +126,7 @@
     {
       "id": "securedDataAccess",
       "type": "radio",
+      "dataType": "single",
       "label": {
         "it": "Indicare se sono state adottate tutte le misure di sicurezza necessarie e/o richieste per l’accesso al dato (richiesto)",
         "en": "Were all necessary and/or required security measures taken before accessing this data? (required)"
@@ -104,13 +135,23 @@
         "it": "Se la risposta a questa domanda è no, prima di procedere con l’invio della richiesta di accesso al presente E-Service per la finalità indicata, si invita a adottare ogni misura di sicurezza necessaria e/o richiesta per l’accesso al dato",
         "en": "If the answer is no, please take all necessary and/or required security measures before accessing this data"
       },
+      "pdfLabel": {
+        "it": "Indicare se sono state adottate tutte le misure di sicurezza necessarie e/o richieste per l’accesso al dato (richiesto)",
+        "en": "Were all necessary and/or required security measures taken before accessing this data? (required)"
+      },
+      "pdfInfoLabel": {
+        "it": "Se la risposta a questa domanda è no, prima di procedere con l’invio della richiesta di accesso al presente E-Service per la finalità indicata, si invita a adottare ogni misura di sicurezza necessaria e/o richiesta per l’accesso al dato",
+        "en": "If the answer is no, please take all necessary and/or required security measures before accessing this data"
+      },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -126,13 +167,22 @@
     {
       "id": "legalBasis",
       "type": "checkbox",
+      "dataType": "multi",
       "label": {
+        "it": "Indicare sulla base di quale, fra le seguenti basi giuridiche ex art. 6 del GDPR, ritiene di essere titolato ad accedere ai dati personali messi a disposizione con la fruizione dell’E-Service (richiesto, scelta multipla)",
+        "en": "Based on GDPR ex art. 6, state on which legal basis you think you are entitled to access the personal data provided with the access to this E-Service (required, multiple choice)"
+      },
+      "pdfLabel": {
         "it": "Indicare sulla base di quale, fra le seguenti basi giuridiche ex art. 6 del GDPR, ritiene di essere titolato ad accedere ai dati personali messi a disposizione con la fruizione dell’E-Service (richiesto, scelta multipla)",
         "en": "Based on GDPR ex art. 6, state on which legal basis you think you are entitled to access the personal data provided with the access to this E-Service (required, multiple choice)"
       },
       "options": [
         {
           "label": {
+            "it": "consenso dell’interessato al trattamento dei dati personali per una o più specifiche finalità",
+            "en": "consent of the interested party to the treatment of personal data for one or more purposes"
+          },
+          "pdfLabel": {
             "it": "consenso dell’interessato al trattamento dei dati personali per una o più specifiche finalità",
             "en": "consent of the interested party to the treatment of personal data for one or more purposes"
           },
@@ -143,10 +193,18 @@
             "it": "esecuzione di un contratto di cui l'interessato è parte o di misure precontrattuali adottate su richiesta dello stesso",
             "en": "execution of a contract which the party is part of or precontractual measures adopted upon request of said party"
           },
+          "pdfLabel": {
+            "it": "esecuzione di un contratto di cui l'interessato è parte o di misure precontrattuali adottate su richiesta dello stesso",
+            "en": "execution of a contract which the party is part of or precontractual measures adopted upon request of said party"
+          },
           "value": "CONTRACT"
         },
         {
           "label": {
+            "it": "adempimento di un obbligo legale",
+            "en": "fulfillment of a legal obligation"
+          },
+          "pdfLabel": {
             "it": "adempimento di un obbligo legale",
             "en": "fulfillment of a legal obligation"
           },
@@ -157,6 +215,10 @@
             "it": "salvaguardia degli interessi vitali di una persona fisica",
             "en": "safeguard of vital interests of a physical person"
           },
+          "pdfLabel": {
+            "it": "salvaguardia degli interessi vitali di una persona fisica",
+            "en": "safeguard of vital interests of a physical person"
+          },
           "value": "SAFEGUARD"
         },
         {
@@ -164,10 +226,18 @@
             "it": "esecuzione di un compito di interesse pubblico o connesso all'esercizio di pubblici poteri di cui sei investito",
             "en": "execution of a task of public interest or connected to the exercise of public authority bestowed upon you"
           },
+          "pdfLabel": {
+            "it": "esecuzione di un compito di interesse pubblico o connesso all'esercizio di pubblici poteri di cui sei investito",
+            "en": "execution of a task of public interest or connected to the exercise of public authority bestowed upon you"
+          },
           "value": "PUBLIC_INTEREST"
         },
         {
           "label": {
+            "it": "perseguimento del legittimo interesse del titolare del trattamento o di terzi, a condizione che non prevalgano gli interessi o i diritti e le libertà fondamentali dell'interessato che richiedono la protezione dei dati personali, in particolare se l'interessato è un minore",
+            "en": "pursue of a legitimate interest of the owner of the treatment or of a third party, on condition that the interest, rights and fundamental freedoms of the interested party that require personal data protection not prevail, with particular interests in case of a minor"
+          },
+          "pdfLabel": {
             "it": "perseguimento del legittimo interesse del titolare del trattamento o di terzi, a condizione che non prevalgano gli interessi o i diritti e le libertà fondamentali dell'interessato che richiedono la protezione dei dati personali, in particolare se l'interessato è un minore",
             "en": "pursue of a legitimate interest of the owner of the treatment or of a third party, on condition that the interest, rights and fundamental freedoms of the interested party that require personal data protection not prevail, with particular interests in case of a minor"
           },
@@ -186,7 +256,12 @@
     {
       "id": "legalObligationReference",
       "type": "text",
+      "dataType": "freeText",
       "label": {
+        "it": "Inserire riferimento normativo per adempimento di un obbligo legale (richiesto)",
+        "en": "State the normative reference towards the fulfillment of a legal obligation (required)"
+      },
+      "pdfLabel": {
         "it": "Inserire riferimento normativo per adempimento di un obbligo legale (richiesto)",
         "en": "State the normative reference towards the fulfillment of a legal obligation (required)"
       },
@@ -202,7 +277,12 @@
     {
       "id": "publicInterestReference",
       "type": "text",
+      "dataType": "freeText",
       "label": {
+        "it": "Inserire riferimento normativo per esecuzione di un compito di interesse pubblico o connesso all'esercizio di pubblici poteri di cui sei investito (richiesto)",
+        "en": "State the normative reference for the execution of a public interest task, or connected to the exercise of public powers bestowed upon you (required)"
+      },
+      "pdfLabel": {
         "it": "Inserire riferimento normativo per esecuzione di un compito di interesse pubblico o connesso all'esercizio di pubblici poteri di cui sei investito (richiesto)",
         "en": "State the normative reference for the execution of a public interest task, or connected to the exercise of public powers bestowed upon you (required)"
       },
@@ -218,17 +298,24 @@
     {
       "id": "knowsAccessedDataCategories",
       "type": "radio",
+      "dataType": "single",
       "label": {
+        "it": "Indicare se si conosce la tipologia di dati personali cui si avrà accesso attraverso la fruizione del presente E-Service di cui alle definizioni contenute nell’art. 4, nn. 1, 13, 14 e 15 del GDPR (richiesto)",
+        "en": "Do you know the type of personal data you will have access to with the subscription to this E-Service? (required)"
+      },
+      "pdfLabel": {
         "it": "Indicare se si conosce la tipologia di dati personali cui si avrà accesso attraverso la fruizione del presente E-Service di cui alle definizioni contenute nell’art. 4, nn. 1, 13, 14 e 15 del GDPR (richiesto)",
         "en": "Do you know the type of personal data you will have access to with the subscription to this E-Service? (required)"
       },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -244,17 +331,24 @@
     {
       "id": "accessDataArt9Gdpr",
       "type": "radio",
+      "dataType": "single",
       "label": {
+        "it": "Indicare se si accederà a particolari categorie di dati personali ex art. 9 del GDPR (richiesto)",
+        "en": "Will you access personal data of peculiar categories with reference to the GDPR ex art. 9? (required)"
+      },
+      "pdfLabel": {
         "it": "Indicare se si accederà a particolari categorie di dati personali ex art. 9 del GDPR (richiesto)",
         "en": "Will you access personal data of peculiar categories with reference to the GDPR ex art. 9? (required)"
       },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -274,17 +368,24 @@
     {
       "id": "accessUnderageData",
       "type": "radio",
+      "dataType": "single",
       "label": {
+        "it": "Indicare se si accederà a dati di minori ex art. 8 del GDPR (richiesto)",
+        "en": "Will you access underage data with reference to the GDPR ex art. 8? (required)"
+      },
+      "pdfLabel": {
         "it": "Indicare se si accederà a dati di minori ex art. 8 del GDPR (richiesto)",
         "en": "Will you access underage data with reference to the GDPR ex art. 8? (required)"
       },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -304,17 +405,24 @@
     {
       "id": "knowsDataQuantity",
       "type": "radio",
+      "dataType": "single",
       "label": {
+        "it": "Indicare se si conosce la quantità di dati personali di cui si entrerà in possesso attraverso la fruizione del presente E-Service (richiesto)",
+        "en": "Do you know how much personal data you will access through the subscription of this E-Service? (required)"
+      },
+      "pdfLabel": {
         "it": "Indicare se si conosce la quantità di dati personali di cui si entrerà in possesso attraverso la fruizione del presente E-Service (richiesto)",
         "en": "Do you know how much personal data you will access through the subscription of this E-Service? (required)"
       },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -330,6 +438,7 @@
     {
       "id": "dataQuantity",
       "type": "select-one",
+      "dataType": "single",
       "label": {
         "it": "Fascia di riferimento (richiesto)",
         "en": "Reference range (required)"
@@ -338,25 +447,38 @@
         "it": "Si richiede di specificare la fascia di riferimento fra quelle di seguito indicate anche in funzione del periodo di validità del voucher emesso per la fruizione dell’E-Service",
         "en": "You are required to state the reference range among the options given, keeping in mind the expiration of the access token (voucher) emitted for the fruition of the E-Service"
       },
+      "pdfLabel": {
+        "it": "Fascia di riferimento (richiesto)",
+        "en": "Reference range (required)"
+      },
+      "pdfInfoLabel": {
+        "it": "Si richiede di specificare la fascia di riferimento fra quelle di seguito indicate anche in funzione del periodo di validità del voucher emesso per la fruizione dell’E-Service",
+        "en": "You are required to state the reference range among the options given, keeping in mind the expiration of the access token (voucher) emitted for the fruition of the E-Service"
+      },
       "options": [
         {
           "label": { "it": "0-100", "en": "0-100" },
+          "pdfLabel": { "it": "0-100", "en": "0-100" },
           "value": "QUANTITY_0_TO_100"
         },
         {
           "label": { "it": "101-500", "en": "101-500" },
+          "pdfLabel": { "it": "101-500", "en": "101-500" },
           "value": "QUANTITY_101_TO_500"
         },
         {
           "label": { "it": "501-1000", "en": "501-1000" },
+          "pdfLabel": { "it": "501-1000", "en": "501-1000" },
           "value": "QUANTITY_500_TO_1000"
         },
         {
           "label": { "it": "1001-5000", "en": "1001-5000" },
+          "pdfLabel": { "it": "1001-5000", "en": "1001-5000" },
           "value": "QUANTITY_1001_TO_5000"
         },
         {
           "label": { "it": "da 5001 in su", "en": "5001 and above" },
+          "pdfLabel": { "it": "da 5001 in su", "en": "5001 and above" },
           "value": "QUANTITY_5001_OVER"
         }
       ],
@@ -376,6 +498,7 @@
     {
       "id": "deliveryMethod",
       "type": "select-one",
+      "dataType": "single",
       "label": {
         "it": "Modalità di erogazione (richiesto)",
         "en": "Delivery mode (required)"
@@ -384,33 +507,33 @@
         "it": "Indicare con quali modalità il Fruitore intende ricevere le informazioni dall’Erogatore, d’accordo con quelle già previste dall’Erogatore stesso",
         "en": "State how the Subscriber will receive the information from the Provider, in accordance with the ones already provided by the Provider"
       },
+      "pdfLabel": {
+        "it": "Modalità di erogazione (richiesto)",
+        "en": "Delivery mode (required)"
+      },
+      "pdfInfoLabel": {
+        "it": "Indicare con quali modalità il Fruitore intende ricevere le informazioni dall’Erogatore, d’accordo con quelle già previste dall’Erogatore stesso",
+        "en": "State how the Subscriber will receive the information from the Provider, in accordance with the ones already provided by the Provider"
+      },
       "options": [
         {
-          "label": {
-            "it": "in chiaro",
-            "en": "cleartext"
-          },
+          "label": { "it": "in chiaro", "en": "cleartext" },
+          "pdfLabel": { "it": "in chiaro", "en": "cleartext" },
           "value": "CLEARTEXT"
         },
         {
-          "label": {
-            "it": "in forma aggregata",
-            "en": "aggregated"
-          },
+          "label": { "it": "in forma aggregata", "en": "aggregated" },
+          "pdfLabel": { "it": "in forma aggregata", "en": "aggregated" },
           "value": "AGGREGATE"
         },
         {
-          "label": {
-            "it": "in forma anonimizzata",
-            "en": "anonymized"
-          },
+          "label": { "it": "in forma anonimizzata", "en": "anonymized" },
+          "pdfLabel": { "it": "in forma anonimizzata", "en": "anonymized" },
           "value": "ANONYMOUS"
         },
         {
-          "label": {
-            "it": "in forma pseudoanonimizzata",
-            "en": "pseudonymized"
-          },
+          "label": { "it": "in forma pseudoanonimizzata", "en": "pseudonymized" },
+          "pdfLabel": { "it": "in forma pseudoanonimizzata", "en": "pseudonymized" },
           "value": "PSEUDOANONYMOUS"
         }
       ],
@@ -426,6 +549,7 @@
     {
       "id": "doneDpia",
       "type": "radio",
+      "dataType": "single",
       "label": {
         "it": "Indicare se è stata fatta un’apposita valutazione di impatto (c.d. DPIA) relativamente alle attività di trattamento dei dati personali che saranno effettuate attraverso la fruizione del presente E-Service (richiesto)",
         "en": "Have you done an impact assessment (c.d. DPIA) with reference to the personal data handling activities that will be carried out through the fruition of the present E-Service? (required)"
@@ -434,13 +558,23 @@
         "it": "Se la risposta a questa domanda è no, si invita a fare tale valutazione prima di fruire dell’E-Service",
         "en": "If the answer is no, please do this evaluation before accessing the E-Service"
       },
+      "pdfLabel": {
+        "it": "Indicare se è stata fatta un’apposita valutazione di impatto (c.d. DPIA) relativamente alle attività di trattamento dei dati personali che saranno effettuate attraverso la fruizione del presente E-Service (richiesto)",
+        "en": "Have you done an impact assessment (c.d. DPIA) with reference to the personal data handling activities that will be carried out through the fruition of the present E-Service? (required)"
+      },
+      "pdfInfoLabel": {
+        "it": "Se la risposta a questa domanda è no, si invita a fare tale valutazione prima di fruire dell’E-Service",
+        "en": "If the answer is no, please do this evaluation before accessing the E-Service"
+      },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -456,6 +590,7 @@
     {
       "id": "definedDataRetentionPeriod",
       "type": "radio",
+      "dataType": "single",
       "label": {
         "it": "Indicare se è stato determinato un periodo di conservazione dei dati cui si avrà accesso attraverso il presente E-Service (richiesto)",
         "en": "Have you determined a data retention period you will have access to through the fruition of the E-Service? (required)"
@@ -464,13 +599,23 @@
         "it": "Se la risposta a questa domanda è no, si invita a determinare tale periodo prima di fruire dell’E-Service",
         "en": "If the answer is no, please determine such period before accessing the E-Service"
       },
+      "pdfLabel": {
+        "it": "Indicare se è stato determinato un periodo di conservazione dei dati cui si avrà accesso attraverso il presente E-Service (richiesto)",
+        "en": "Have you determined a data retention period you will have access to through the fruition of the E-Service? (required)"
+      },
+      "pdfInfoLabel": {
+        "it": "Se la risposta a questa domanda è no, si invita a determinare tale periodo prima di fruire dell’E-Service",
+        "en": "If the answer is no, please determine such period before accessing the E-Service"
+      },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -486,7 +631,12 @@
     {
       "id": "purposePursuit",
       "type": "radio",
+      "dataType": "single",
       "label": {
+        "it": "Per perseguire la finalità dichiarata, indicare se (richiesto)",
+        "en": "To pursue this purpose, please state if (required)"
+      },
+      "pdfLabel": {
         "it": "Per perseguire la finalità dichiarata, indicare se (richiesto)",
         "en": "To pursue this purpose, please state if (required)"
       },
@@ -496,10 +646,18 @@
             "it": "è sufficiente che l’Erogatore verifichi la mera correttezza di una/o determinata/o informazione/dato personale già in suo possesso",
             "en": "it is sufficient for the Provider to check the mere correctedness of a particular information or personal data they already own"
           },
+          "pdfLabel": {
+            "it": "è sufficiente che l’Erogatore verifichi la mera correttezza di una/o determinata/o informazione/dato personale già in suo possesso",
+            "en": "it is sufficient for the Provider to check the mere correctedness of a particular information or personal data they already own"
+          },
           "value": "MERE_CORRECTNESS"
         },
         {
           "label": {
+            "it": "è necessario ricevere ex novo una/o determinata/o informazione/dato personale",
+            "en": "it is necessary to receive the information or personal data ex novo"
+          },
+          "pdfLabel": {
             "it": "è necessario ricevere ex novo una/o determinata/o informazione/dato personale",
             "en": "it is necessary to receive the information or personal data ex novo"
           },
@@ -518,13 +676,19 @@
     {
       "id": "checkedExistenceMereCorrectnessInteropCatalogue",
       "type": "checkbox",
+      "dataType": "single",
       "label": {
+        "it": "Confermare se è stato verificato se sul Catalogo API è presente un altro E-Service in grado di svolgere questa attività di mera verifica (che non preveda ex novo la comunicazione di altri informazioni/dati personali – richiesto)",
+        "en": "Have you checked if there is another E-Service in the Catalog that allows you to carry out this simple check task (in case it does not require the ex novo transmission of other information/personal data)? (required)"
+      },
+      "pdfLabel": {
         "it": "Confermare se è stato verificato se sul Catalogo API è presente un altro E-Service in grado di svolgere questa attività di mera verifica (che non preveda ex novo la comunicazione di altri informazioni/dati personali – richiesto)",
         "en": "Have you checked if there is another E-Service in the Catalog that allows you to carry out this simple check task (in case it does not require the ex novo transmission of other information/personal data)? (required)"
       },
       "options": [
         {
           "label": { "it": "Confermo", "en": "Confirm" },
+          "pdfLabel": { "it": "Confermo", "en": "Confirm" },
           "value": "YES"
         }
       ],
@@ -544,17 +708,24 @@
     {
       "id": "checkedAllDataNeeded",
       "type": "radio",
+      "dataType": "single",
       "label": {
+        "it": "Indicare se è stato verificato se occorrono necessariamente tutte le informazioni e i dati personali messi a disposizione con il presente E-Service (richiesto)",
+        "en": "Did you check if it necessary for you to access all the information and personal data provided with the present E-Service? (required)"
+      },
+      "pdfLabel": {
         "it": "Indicare se è stato verificato se occorrono necessariamente tutte le informazioni e i dati personali messi a disposizione con il presente E-Service (richiesto)",
         "en": "Did you check if it necessary for you to access all the information and personal data provided with the present E-Service? (required)"
       },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -574,6 +745,7 @@
     {
       "id": "checkedExistenceMinimalDataInteropCatalogue",
       "type": "radio",
+      "dataType": "single",
       "label": {
         "it": "Indicare se si è verificato se sul Catalogo API è presente un altro E-Service che consenta di accedere alle sole informazioni/dati personali di cui si necessita (richiesto)",
         "en": "Did you check if another E-Service that allows you to only access the information/personal data you need is present on the Catalog? (required)"
@@ -582,13 +754,23 @@
         "it": "Se la risposta a questa domanda è no, per evitare comunicazioni di informazioni/dati personali non necessarie, si invita a sollecitare un Erogatore ad attivare un E-Service che consenta di accedere ai soli dati personali di cui si necessita e, una volta attivato, si invita a inviare una richiesta di accesso per quell’E-Service",
         "en": "If the answer is no, please check the Catalog for E-Services that allow you to only access the information/personal data you need"
       },
+      "pdfLabel": {
+        "it": "Indicare se si è verificato se sul Catalogo API è presente un altro E-Service che consenta di accedere alle sole informazioni/dati personali di cui si necessita (richiesto)",
+        "en": "Did you check if another E-Service that allows you to only access the information/personal data you need is present on the Catalog? (required)"
+      },
+      "pdfInfoLabel": {
+        "it": "Se la risposta a questa domanda è no, per evitare comunicazioni di informazioni/dati personali non necessarie, si invita a sollecitare un Erogatore ad attivare un E-Service che consenta di accedere ai soli dati personali di cui si necessita e, una volta attivato, si invita a inviare una richiesta di accesso per quell’E-Service",
+        "en": "If the answer is no, please check the Catalog for E-Services that allow you to only access the information/personal data you need"
+      },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],

--- a/src/main/resources/riskAnalysisTemplate/forms/1.0.json
+++ b/src/main/resources/riskAnalysisTemplate/forms/1.0.json
@@ -676,7 +676,7 @@
     {
       "id": "checkedExistenceMereCorrectnessInteropCatalogue",
       "type": "checkbox",
-      "dataType": "single",
+      "dataType": "multi",
       "label": {
         "it": "Confermare se è stato verificato se sul Catalogo API è presente un altro E-Service in grado di svolgere questa attività di mera verifica (che non preveda ex novo la comunicazione di altri informazioni/dati personali – richiesto)",
         "en": "Have you checked if there is another E-Service in the Catalog that allows you to carry out this simple check task (in case it does not require the ex novo transmission of other information/personal data)? (required)"

--- a/src/main/resources/riskAnalysisTemplate/forms/2.0.json
+++ b/src/main/resources/riskAnalysisTemplate/forms/2.0.json
@@ -38,6 +38,10 @@
             "it": "Altro",
             "en": "Other"
           },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
+          },
           "value": "OTHER"
         }
       ],
@@ -52,6 +56,10 @@
       "label": {
         "it": "Specificare il fine perseguito per fini istituzionali che non richiedano prestazioni di elaborazioni aggiuntive (richiesto)",
         "en": "TODO (required)"
+      },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
       },
       "defaultValue": "",
       "required": true,
@@ -70,6 +78,10 @@
         "it": "Specificare il fine perseguito (richiesto)",
         "en": "TODO (required)"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "defaultValue": "",
       "required": true,
       "dependencies": [
@@ -87,11 +99,19 @@
         "it": "Indicare la tipologia di dati personali cui si avrà accesso attraverso la fruizione del presente E-service, tenuto conto delle definizioni contenute nell’art. 4, nn. 1, 13, 14 e 15 del GDPR (richiesto, scelta multipla)",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": {
             "it": "Dati personali comuni non identificativi (es. numero di targa)",
             "en": "TODO"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "WITH_NON_IDENTIFYING_DATA"
         },
@@ -100,12 +120,20 @@
             "it": "Dati personali comuni identificativi (es. codice fiscale)",
             "en": "TODO"
           },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
+          },
           "value": "WITH_IDENTIFYING_DATA"
         },
         {
           "label": {
             "it": "Dati di minori ex art. 8 del GDPR (es. nome e cognome di un minore)",
             "en": "TODO"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "GDPR_ART_8"
         },
@@ -114,6 +142,10 @@
             "it": "Dati particolari ex art. 9 del GDPR (es. origine razziale o etnica, opinioni politiche, convinzioni religiose o filosofiche, appartenenza sindacale, nonché dati genetici, biometrici intesi a identificare in modo univoco una persona fisica, dati relativi alla salute o alla vita sessuale o all'orientamento sessuale della persona)",
             "en": "TODO"
           },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
+          },
           "value": "GDPR_ART_9"
         },
         {
@@ -121,12 +153,20 @@
             "it": "Dati giudiziari ex art. 10 del GDPR (es. provvedimenti penali di condanna definitivi, liberazione condizionale, divieto od obbligo di soggiorno, misure alternative alla detenzione)",
             "en": "TODO"
           },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
+          },
           "value": "GDPR_ART_10"
         },
         {
           "label": {
             "it": "Altro",
             "en": "TODO"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "OTHER"
         }
@@ -142,6 +182,10 @@
       "label": {
         "it": "Specificare la tipologia di dati personali (richiesto)",
         "en": "TODO (required)"
+      },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
       },
       "defaultValue": "",
       "required": true,
@@ -160,11 +204,19 @@
         "it": "Indicare sulla base di quale, fra le seguenti basi giuridiche ex art. 6 del GDPR, ritiene di essere titolato ad accedere ai dati personali messi a disposizione con la fruizione dell’E-Service (richiesto, scelta multipla)",
         "en": "Based on GDPR ex art. 6, state on which legal basis you think you are entitled to access the personal data provided with the access to this E-Service (required, multiple choice)"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": {
             "it": "consenso dell’interessato al trattamento dei dati personali per una o più specifiche finalità",
             "en": "consent of the interested party to the treatment of personal data for one or more purposes"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "CONSENT"
         },
@@ -173,12 +225,20 @@
             "it": "esecuzione di un contratto di cui l'interessato è parte o di misure precontrattuali adottate su richiesta dello stesso",
             "en": "execution of a contract which the party is part of or precontractual measures adopted upon request of said party"
           },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
+          },
           "value": "CONTRACT"
         },
         {
           "label": {
             "it": "adempimento di un obbligo legale",
             "en": "fulfillment of a legal obligation"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "LEGAL_OBLIGATION"
         },
@@ -187,12 +247,20 @@
             "it": "salvaguardia degli interessi vitali di una persona fisica",
             "en": "safeguard of vital interests of a physical person"
           },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
+          },
           "value": "SAFEGUARD"
         },
         {
           "label": {
             "it": "esecuzione di un compito di interesse pubblico o connesso all'esercizio di pubblici poteri di cui sei investito",
             "en": "execution of a task of public interest or connected to the exercise of public authority bestowed upon you"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "PUBLIC_INTEREST"
         }
@@ -213,6 +281,14 @@
         "it": "specificare l’obbligo legale e, laddove possibile, la normativa di riferimento",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
+      },
       "defaultValue": "",
       "required": true,
       "dependencies": [
@@ -230,11 +306,19 @@
         "it": "Specificare le motivazioni di esecuzione di un compito di interesse pubblico o connesso all'esercizio di pubblici poteri di cui sei investito (richiesto)",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": {
             "it": "norma di legge o di regolamento ai sensi dell’art. 2-ter, comma 1, del Codice Privacy per quanto attiene ai dati personali comuni e ai sensi dell’art. 2- sexies, comma 1 del Codice Privacy per quanto attiene alle categorie particolari di dati",
             "en": "TODO"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "RULE_OF_LAW"
         },
@@ -243,12 +327,20 @@
             "it": "atto amministrativo generale ai sensi dell’art. 2-ter, comma 1, del Codice Privacy per quanto attiene ai dati personali comuni e ai sensi dell’art. 2-sexies, comma 1 del Codice Privacy per quanto attiene alle categorie particolari di dati",
             "en": "TODO"
           },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
+          },
           "value": "ADMINISTRATIVE_ACT"
         },
         {
           "label": {
             "it": "adempimento di un compito svolto nel pubblico interesse o per l’esecuzione di pubblici poteri attribuiti al Fruitore ai sensi dell’art. 2-ter, comma 1 bis, del Codice Privacy",
             "en": "TODO"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "PUBLIC_INTEREST_TASK"
         }
@@ -282,6 +374,14 @@
         "it": "norma di legge o di regolamento ai sensi dell’art. 2-ter, comma 1, del Codice Privacy per quanto attiene ai dati personali comuni e ai sensi dell’art. 2- sexies, comma 1 del Codice Privacy per quanto attiene alle categorie particolari di dati",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
+      },
       "defaultValue": "",
       "required": true,
       "dependencies": [
@@ -302,6 +402,14 @@
       "infoLabel": {
         "it": "atto amministrativo generale ai sensi dell’art. 2-ter, comma 1, del Codice Privacy per quanto attiene ai dati personali comuni e ai sensi dell’art. 2-sexies, comma 1 del Codice Privacy per quanto attiene alle categorie particolari di dati",
         "en": "TODO"
+      },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
       },
       "defaultValue": "",
       "required": true,
@@ -324,6 +432,14 @@
         "it": "adempimento di un compito svolto nel pubblico interesse o per l’esecuzione di pubblici poteri attribuiti al Fruitore ai sensi dell’art. 2-ter, comma 1 bis, del Codice Privacy",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
+      },
       "defaultValue": "",
       "required": true,
       "dependencies": [
@@ -341,13 +457,19 @@
         "it": "Indicare se si conosce la quantità di dati personali di cui si entrerà in possesso attraverso la fruizione del presente E-Service (richiesto)",
         "en": "Do you know how much personal data you will access through the subscription of this E-Service? (required)"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "", "en": "" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -367,25 +489,38 @@
         "it": "Si richiede di specificare la fascia di riferimento fra quelle di seguito indicate anche in funzione del periodo di validità del voucher emesso per la fruizione dell’E-Service",
         "en": "You are required to state the reference range among the options given, keeping in mind the expiration of the access token (voucher) emitted for the fruition of the E-Service"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": { "it": "0-100", "en": "0-100" },
+          "pdfLabel": { "it": "0-100", "en": "0-100" },
           "value": "QUANTITY_0_TO_100"
         },
         {
           "label": { "it": "101-500", "en": "101-500" },
+          "pdfLabel": { "it": "101-500", "en": "101-500" },
           "value": "QUANTITY_101_TO_500"
         },
         {
           "label": { "it": "501-1000", "en": "501-1000" },
+          "pdfLabel": { "it": "501-1000", "en": "501-1000" },
           "value": "QUANTITY_500_TO_1000"
         },
         {
           "label": { "it": "1001-5000", "en": "1001-5000" },
+          "pdfLabel": { "it": "1001-5000", "en": "1001-5000" },
           "value": "QUANTITY_1001_TO_5000"
         },
         {
           "label": { "it": "da 5001 in su", "en": "5001 and up" },
+          "pdfLabel": { "it": "da 5001 in su", "en": "5001 and up" },
           "value": "QUANTITY_5001_OVER"
         }
       ],
@@ -410,11 +545,23 @@
         "it": "Indicare con quali modalità il Fruitore intende ricevere le informazioni dall’Erogatore, d’accordo con quelle già previste dall’Erogatore stesso. NB: si ricorda che ai sensi dell’art. 5, paragrafo 1, lett. c), del GDPR (principio di minimizzazione) il trattamento di dati personali deve essere sempre proporzionale e limitato a quanto strettamente necessario alla finalità perseguita, e possono essere acceduti tramite l’e-service unicamente i dati adeguati, pertinenti e limitati a quanto necessario per il fine perseguito. Pertanto: (i) solo qualora non sia possibile perseguire le finalità dichiarate nel punto 1 sopra sulla base di dati aggregati o anonimi è possibile barrare le opzioni di dati in chiaro e pseudonimizzati e (ii) solo qualora non sia possibile perseguire le predette finalità con dati pseudonimizzati è possibile barrare l’opzione di dati in chiaro.",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": {
             "it": "in chiaro",
             "en": "cleartext"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "CLEARTEXT"
         },
@@ -423,6 +570,10 @@
             "it": "in forma pseudoanonimizzata",
             "en": "pseudonymized"
           },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
+          },
           "value": "PSEUDOANONYMOUS"
         },
         {
@@ -430,12 +581,20 @@
             "it": "in forma aggregata",
             "en": "aggregated"
           },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
+          },
           "value": "AGGREGATE"
         },
         {
           "label": {
             "it": "in forma anonimizzata",
             "en": "anonymized"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "ANONYMOUS"
         }
@@ -452,13 +611,19 @@
         "it": "Indicare se è stata fornita un’informativa all’interessato circa l’accesso ai dati cui si intende accedere/che si intende ricevere tramite la fruizione dell’E-Service e le relative attività di trattamento effettuate dal Fruitore: (richiesto)",
         "en": "TODO (required)"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -478,6 +643,14 @@
         "it": "Di norma sì fornisce un’informativa all’interessato circa l’accesso ai dati cui si intende accedere/che si intende ricevere tramite la fruizione dell’E-Service e le relative attività di trattamento effettuate dal Fruitore",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
+      },
       "defaultValue": "",
       "required": true,
       "dependencies": [
@@ -495,14 +668,20 @@
         "it": "Confermare se - in linea con il principio di integrità e riservatezza di cui all’art. 5, paragrafo 1, lett. f), del GDPR - sono state adottate tutte le misure tecniche e organizzative necessarie a garantire un’adeguata sicurezza dei dati personali cui si avrà accesso in sede di fruizione del presente E-service, compresa la protezione da trattamenti non autorizzati o illeciti e dalla perdita, dalla distruzione o dal danno accidentali. (richiesto)",
         "en": "TODO (required)"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": {"it": "Confermo", "en": "Confirm"},
-          "value": true
+          "pdfLabel": {"it": "Confermo", "en": "Confirm"},
+          "value": "true"
         },
         {
           "label": {"it": "Nego", "en": "Deny"},
-          "value": false,
+          "pdfLabel": {"it": "Nego", "en": "Deny"},
+          "value": "false",
           "forceUserCheckEServiceCatalog": true
         }
       ],
@@ -522,13 +701,23 @@
         "it": "Se la risposta a questa domanda è no, si ricorda che la valutazione di impatto è obbligatoria ​​qualora sussistano le condizioni di cui all’art. 35 del GDPR.",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -548,13 +737,23 @@
         "it": "Se la risposta a questa domanda è no, si ricorda che la consultazione preventiva è obbligatoria ​​qualora sussistano le condizioni di cui all’art. 36 del GDPR.",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -579,14 +778,24 @@
         "it": "NB: si ricorda che il download del dato non consente di disporre di un dato aggiornato, e quindi di agire nel rispetto del principio di esattezza dei dati di cui all’art. 5, paragrafo 1, lettera d), del GDPR. Pertanto, si invita a limitare i casi di download del dato alle ipotesi in cui tale download è strettamente necessario e giustificato dalla finalità del trattamento. Si ricorda, altresì, che, ai sensi dell’art. 5, paragrafo 1, lett. b) ed e) del GDPR (principio della limitazione della finalità e della conservazione) , i dati possono essere conservati unicamente per il tempo strettamente necessario al perseguimento delle finalità per cui sono stati raccolti, e che le stesse siano determinate, esplicite e legittime.",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": {"it": "Confermo", "en": "Confirm"},
-          "value": true
+          "pdfLabel": {"it": "Confermo", "en": "Confirm"},
+          "value": "true"
         },
         {
           "label": {"it": "Nego", "en": "Deny"},
-          "value": false,
+          "pdfLabel": {"it": "Nego", "en": "Deny"},
+          "value": "false",
           "forceUserCheckEServiceCatalog": true
         }
       ],
@@ -602,11 +811,19 @@
         "it": "Ai sensi del principio di minimizzazione di cui all’art. 5, paragrafo 1, let. c) del GDPR, per perseguire la finalità di cui al punto 1, indicare se (richiesto)",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": {
             "it": "è sufficiente che l’Erogatore verifichi la mera correttezza di una/o determinata/o informazione/dato personale già in suo possesso",
             "en": "it is sufficient for the Provider to check the mere correctedness of a particular information or personal data they already own"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "MERE_CORRECTNESS"
         },
@@ -614,6 +831,10 @@
           "label": {
             "it": "è necessario ricevere ex novo una/o determinata/o informazione/dato personale",
             "en": "it is necessary to receive the information or personal data ex novo"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
           },
           "value": "NEW_PERSONAL_DATA"
         }
@@ -630,14 +851,20 @@
         "it": "Confermare se è stato verificato se sul Catalogo API è presente un altro E-Service in grado di svolgere questa attività di mera verifica (che non preveda ex novo la comunicazione di altri informazioni/dati personali – richiesto)",
         "en": "Have you checked if there is another E-Service in the Catalog that allows you to carry out this simple check task (in case it does not require the ex novo transmission of other information/personal data)? (required)"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": {"it": "Confermo", "en": "Confirm"},
-          "value": true
+          "pdfLabel": {"it": "Confermo", "en": "Confirm"},
+          "value": "true"
         },
         {
           "label": {"it": "Nego", "en": "Deny"},
-          "value": false,
+          "pdfLabel": {"it": "Nego", "en": "Deny"},
+          "value": "false",
           "forceUserCheckEServiceCatalog": true,
           "blockedAlert": {
             "it": "Prima di procedere con l’invio della richiesta di accesso al presente E-service per la finalità indicata al punto 1, si invita a verificare se sul Catalogo API è presente un altro E-service che consenta di svolgere la mera attività di verifica di informazioni/dati personali di cui si necessita",
@@ -666,13 +893,23 @@
         "it": "Se la risposta a questa domanda è no, si invita a verificare se sul Catalogo API è presente un altro E-service che consenta di accedere alle sole informazioni/dati personali di cui si necessita.",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO",
           "forceUserCheckEServiceCatalog": true,
           "blockedAlert": {
@@ -698,13 +935,19 @@
         "it": "Indicare se si accede a dati su richiesta/per conto di terzi soggetti (richiesto)",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -720,13 +963,19 @@
         "it": "Indicare se si accede a dati per conto di un soggetto di cui all’art. 2, comma 2, lett. a) del CAD (richiesto)",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -747,14 +996,20 @@
         "it": "Dichiara di essere consapevole degli obblighi di cui al GDPR in tema di trattamento di dati personali e ​​dichiara di essere in grado di comprovarne il rispetto (principio di responsabilizzazione di cui all’art. 5, paragrafo 2, del GDPR). (richiesto)",
         "en": "TODO"
       },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
       "options": [
         {
           "label": {"it": "Confermo", "en": "Confirm"},
-          "value": true
+          "pdfLabel": {"it": "Confermo", "en": "Confirm"},
+          "value": "true"
         },
         {
           "label": {"it": "Nego", "en": "Deny"},
-          "value": false
+          "pdfLabel": {"it": "Nego", "en": "Deny"},
+          "value": "false"
         }
       ],
       "defaultValue": false,

--- a/src/main/resources/riskAnalysisTemplate/forms/2.0.json
+++ b/src/main/resources/riskAnalysisTemplate/forms/2.0.json
@@ -1,0 +1,765 @@
+{
+  "version": "2.0",
+  "questions": [
+    {
+      "id": "purpose",
+      "type": "radio",
+      "dataType": "single",
+      "label": {
+        "it": "Indicare per quale finalità si intende accedere ai dati messi a disposizione con la fruizione del presente E-service (richiesto)",
+        "en": "TODO (required)"
+      },
+      "infoLabel": {
+        "it": "NB: Si ricorda ai sensi dell'art. 5, paragrafo 1, lett. b), del GDPR (principio della limitazione delle finalità), le finalità devono essere determinate, esplicite e legittime, e che i dati ottenuti possono essere successivamente trattati solo in modo compatibile con le predette finalità. Si ricorda, altresì, che qualora sussista più di una finalità, il Fruitore DEVE effettuare un'analisi del rischio per ognuna delle finalità individuate",
+        "en": "TODO"
+      },
+      "pdfLabel": {
+        "it": "",
+        "en": ""
+      },
+      "pdfInfoLabel": {
+        "it": "",
+        "en": ""
+      },
+      "options": [
+        {
+          "label": {
+            "it": "Per fini istituzionali che non richiedano prestazioni di elaborazioni aggiuntive",
+            "en": "TODO"
+          },
+          "pdfLabel": {
+            "it": "",
+            "en": ""
+          },
+          "value": "INSTITUTIONAL"
+        },
+        {
+          "label": {
+            "it": "Altro",
+            "en": "Other"
+          },
+          "value": "OTHER"
+        }
+      ],
+      "defaultValue": "INSTITUTIONAL",
+      "required": true,
+      "dependencies": []
+    },
+    {
+      "id": "institutionalPurpose",
+      "type": "text",
+      "dataType": "freeText",
+      "label": {
+        "it": "Specificare il fine perseguito per fini istituzionali che non richiedano prestazioni di elaborazioni aggiuntive (richiesto)",
+        "en": "TODO (required)"
+      },
+      "defaultValue": "",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "purpose",
+          "value": "INSTITUTIONAL"
+        }
+      ]
+    },
+    {
+      "id": "otherPurpose",
+      "type": "text",
+      "dataType": "freeText",
+      "label": {
+        "it": "Specificare il fine perseguito (richiesto)",
+        "en": "TODO (required)"
+      },
+      "defaultValue": "",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "purpose",
+          "value": "OTHER"
+        }
+      ]
+    },
+    {
+      "id": "personalDataTypes",
+      "type": "checkbox",
+      "dataType": "multi",
+      "label": {
+        "it": "Indicare la tipologia di dati personali cui si avrà accesso attraverso la fruizione del presente E-service, tenuto conto delle definizioni contenute nell’art. 4, nn. 1, 13, 14 e 15 del GDPR (richiesto, scelta multipla)",
+        "en": "TODO"
+      },
+      "options": [
+        {
+          "label": {
+            "it": "Dati personali comuni non identificativi (es. numero di targa)",
+            "en": "TODO"
+          },
+          "value": "WITH_NON_IDENTIFYING_DATA"
+        },
+        {
+          "label": {
+            "it": "Dati personali comuni identificativi (es. codice fiscale)",
+            "en": "TODO"
+          },
+          "value": "WITH_IDENTIFYING_DATA"
+        },
+        {
+          "label": {
+            "it": "Dati di minori ex art. 8 del GDPR (es. nome e cognome di un minore)",
+            "en": "TODO"
+          },
+          "value": "GDPR_ART_8"
+        },
+        {
+          "label": {
+            "it": "Dati particolari ex art. 9 del GDPR (es. origine razziale o etnica, opinioni politiche, convinzioni religiose o filosofiche, appartenenza sindacale, nonché dati genetici, biometrici intesi a identificare in modo univoco una persona fisica, dati relativi alla salute o alla vita sessuale o all'orientamento sessuale della persona)",
+            "en": "TODO"
+          },
+          "value": "GDPR_ART_9"
+        },
+        {
+          "label": {
+            "it": "Dati giudiziari ex art. 10 del GDPR (es. provvedimenti penali di condanna definitivi, liberazione condizionale, divieto od obbligo di soggiorno, misure alternative alla detenzione)",
+            "en": "TODO"
+          },
+          "value": "GDPR_ART_10"
+        },
+        {
+          "label": {
+            "it": "Altro",
+            "en": "TODO"
+          },
+          "value": "OTHER"
+        }
+      ],
+      "defaultValue": [],
+      "required": true,
+      "dependencies": []
+    },
+    {
+      "id": "otherPersonalDataTypes",
+      "type": "text",
+      "dataType": "freeText",
+      "label": {
+        "it": "Specificare la tipologia di dati personali (richiesto)",
+        "en": "TODO (required)"
+      },
+      "defaultValue": "",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "personalDataTypes",
+          "value": "OTHER"
+        }
+      ]
+    },
+    {
+      "id": "legalBasis",
+      "type": "checkbox",
+      "dataType": "multi",
+      "label": {
+        "it": "Indicare sulla base di quale, fra le seguenti basi giuridiche ex art. 6 del GDPR, ritiene di essere titolato ad accedere ai dati personali messi a disposizione con la fruizione dell’E-Service (richiesto, scelta multipla)",
+        "en": "Based on GDPR ex art. 6, state on which legal basis you think you are entitled to access the personal data provided with the access to this E-Service (required, multiple choice)"
+      },
+      "options": [
+        {
+          "label": {
+            "it": "consenso dell’interessato al trattamento dei dati personali per una o più specifiche finalità",
+            "en": "consent of the interested party to the treatment of personal data for one or more purposes"
+          },
+          "value": "CONSENT"
+        },
+        {
+          "label": {
+            "it": "esecuzione di un contratto di cui l'interessato è parte o di misure precontrattuali adottate su richiesta dello stesso",
+            "en": "execution of a contract which the party is part of or precontractual measures adopted upon request of said party"
+          },
+          "value": "CONTRACT"
+        },
+        {
+          "label": {
+            "it": "adempimento di un obbligo legale",
+            "en": "fulfillment of a legal obligation"
+          },
+          "value": "LEGAL_OBLIGATION"
+        },
+        {
+          "label": {
+            "it": "salvaguardia degli interessi vitali di una persona fisica",
+            "en": "safeguard of vital interests of a physical person"
+          },
+          "value": "SAFEGUARD"
+        },
+        {
+          "label": {
+            "it": "esecuzione di un compito di interesse pubblico o connesso all'esercizio di pubblici poteri di cui sei investito",
+            "en": "execution of a task of public interest or connected to the exercise of public authority bestowed upon you"
+          },
+          "value": "PUBLIC_INTEREST"
+        }
+      ],
+      "defaultValue": [],
+      "required": true,
+      "dependencies": []
+    },
+    {
+      "id": "legalObligationReference",
+      "type": "text",
+      "dataType": "freeText",
+      "label": {
+        "it": "Inserire riferimento normativo per adempimento di un obbligo legale (richiesto)",
+        "en": "State the normative reference towards the fulfillment of a legal obligation (required)"
+      },
+      "infoLabel": {
+        "it": "specificare l’obbligo legale e, laddove possibile, la normativa di riferimento",
+        "en": "TODO"
+      },
+      "defaultValue": "",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "legalBasis",
+          "value": "LEGAL_OBLIGATION"
+        }
+      ]
+    },
+    {
+      "id": "legalBasisPublicInterest",
+      "type": "radio",
+      "dataType": "single",
+      "label": {
+        "it": "Specificare le motivazioni di esecuzione di un compito di interesse pubblico o connesso all'esercizio di pubblici poteri di cui sei investito (richiesto)",
+        "en": "TODO"
+      },
+      "options": [
+        {
+          "label": {
+            "it": "norma di legge o di regolamento ai sensi dell’art. 2-ter, comma 1, del Codice Privacy per quanto attiene ai dati personali comuni e ai sensi dell’art. 2- sexies, comma 1 del Codice Privacy per quanto attiene alle categorie particolari di dati",
+            "en": "TODO"
+          },
+          "value": "RULE_OF_LAW"
+        },
+        {
+          "label": {
+            "it": "atto amministrativo generale ai sensi dell’art. 2-ter, comma 1, del Codice Privacy per quanto attiene ai dati personali comuni e ai sensi dell’art. 2-sexies, comma 1 del Codice Privacy per quanto attiene alle categorie particolari di dati",
+            "en": "TODO"
+          },
+          "value": "ADMINISTRATIVE_ACT"
+        },
+        {
+          "label": {
+            "it": "adempimento di un compito svolto nel pubblico interesse o per l’esecuzione di pubblici poteri attribuiti al Fruitore ai sensi dell’art. 2-ter, comma 1 bis, del Codice Privacy",
+            "en": "TODO"
+          },
+          "value": "PUBLIC_INTEREST_TASK"
+        }
+      ],
+      "defaultValue": "RULE_OF_LAW",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "legalBasis",
+          "value": "PUBLIC_INTEREST"
+        }
+      ],
+      "hideOption": {
+        "PUBLIC_INTEREST_TASK": [
+          {
+            "id": "personalDataTypes",
+            "value": "GDPR_ART_9"
+          }
+        ]
+      }
+    },
+    {
+      "id": "ruleOfLawText",
+      "type": "text",
+      "dataType": "freeText",
+      "label": {
+        "it": "Inserire norma di legge o di regolamento applicabile (richiesto)",
+        "en": "TODO (required)"
+      },
+      "infoLabel": {
+        "it": "norma di legge o di regolamento ai sensi dell’art. 2-ter, comma 1, del Codice Privacy per quanto attiene ai dati personali comuni e ai sensi dell’art. 2- sexies, comma 1 del Codice Privacy per quanto attiene alle categorie particolari di dati",
+        "en": "TODO"
+      },
+      "defaultValue": "",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "legalBasisPublicInterest",
+          "value": "RULE_OF_LAW"
+        }
+      ]
+    },
+    {
+      "id": "administrativeActText",
+      "type": "text",
+      "dataType": "freeText",
+      "label": {
+        "it": "Inserire il riferimento dell’atto amministrativo generale applicabile (richiesto)",
+        "en": "TODO (required)"
+      },
+      "infoLabel": {
+        "it": "atto amministrativo generale ai sensi dell’art. 2-ter, comma 1, del Codice Privacy per quanto attiene ai dati personali comuni e ai sensi dell’art. 2-sexies, comma 1 del Codice Privacy per quanto attiene alle categorie particolari di dati",
+        "en": "TODO"
+      },
+      "defaultValue": "",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "legalBasisPublicInterest",
+          "value": "ADMINISTRATIVE_ACT"
+        }
+      ]
+    },
+    {
+      "id": "publicInterestTaskText",
+      "type": "text",
+      "dataType": "freeText",
+      "label": {
+        "it": "Inserire il compito svolto o il pubblico il riferimento dell’atto amministrativo generale applicabile (richiesto)",
+        "en": "TODO (required)"
+      },
+      "infoLabel": {
+        "it": "adempimento di un compito svolto nel pubblico interesse o per l’esecuzione di pubblici poteri attribuiti al Fruitore ai sensi dell’art. 2-ter, comma 1 bis, del Codice Privacy",
+        "en": "TODO"
+      },
+      "defaultValue": "",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "legalBasisPublicInterest",
+          "value": "PUBLIC_INTEREST_TASK"
+        }
+      ]
+    },
+    {
+      "id": "knowsDataQuantity",
+      "type": "radio",
+      "dataType": "single",
+      "label": {
+        "it": "Indicare se si conosce la quantità di dati personali di cui si entrerà in possesso attraverso la fruizione del presente E-Service (richiesto)",
+        "en": "Do you know how much personal data you will access through the subscription of this E-Service? (required)"
+      },
+      "options": [
+        {
+          "label": { "it": "Sì", "en": "Yes" },
+          "value": "YES"
+        },
+        {
+          "label": { "it": "No", "en": "No" },
+          "value": "NO"
+        }
+      ],
+      "defaultValue": "NO",
+      "required": true,
+      "dependencies": []
+    },
+    {
+      "id": "dataQuantity",
+      "type": "select-one",
+      "dataType": "single",
+      "label": {
+        "it": "Fascia di riferimento (richiesto)",
+        "en": "Reference range (required)"
+      },
+      "infoLabel": {
+        "it": "Si richiede di specificare la fascia di riferimento fra quelle di seguito indicate anche in funzione del periodo di validità del voucher emesso per la fruizione dell’E-Service",
+        "en": "You are required to state the reference range among the options given, keeping in mind the expiration of the access token (voucher) emitted for the fruition of the E-Service"
+      },
+      "options": [
+        {
+          "label": { "it": "0-100", "en": "0-100" },
+          "value": "QUANTITY_0_TO_100"
+        },
+        {
+          "label": { "it": "101-500", "en": "101-500" },
+          "value": "QUANTITY_101_TO_500"
+        },
+        {
+          "label": { "it": "501-1000", "en": "501-1000" },
+          "value": "QUANTITY_500_TO_1000"
+        },
+        {
+          "label": { "it": "1001-5000", "en": "1001-5000" },
+          "value": "QUANTITY_1001_TO_5000"
+        },
+        {
+          "label": { "it": "da 5001 in su", "en": "5001 and up" },
+          "value": "QUANTITY_5001_OVER"
+        }
+      ],
+      "defaultValue": "QUANTITY_0_TO_100",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "knowsDataQuantity",
+          "value": "YES"
+        }
+      ]
+    },
+    {
+      "id": "deliveryMethod",
+      "type": "select-one",
+      "dataType": "single",
+      "label": {
+        "it": "Modalità di erogazione (richiesto)",
+        "en": "Delivery mode (required)"
+      },
+      "infoLabel": {
+        "it": "Indicare con quali modalità il Fruitore intende ricevere le informazioni dall’Erogatore, d’accordo con quelle già previste dall’Erogatore stesso. NB: si ricorda che ai sensi dell’art. 5, paragrafo 1, lett. c), del GDPR (principio di minimizzazione) il trattamento di dati personali deve essere sempre proporzionale e limitato a quanto strettamente necessario alla finalità perseguita, e possono essere acceduti tramite l’e-service unicamente i dati adeguati, pertinenti e limitati a quanto necessario per il fine perseguito. Pertanto: (i) solo qualora non sia possibile perseguire le finalità dichiarate nel punto 1 sopra sulla base di dati aggregati o anonimi è possibile barrare le opzioni di dati in chiaro e pseudonimizzati e (ii) solo qualora non sia possibile perseguire le predette finalità con dati pseudonimizzati è possibile barrare l’opzione di dati in chiaro.",
+        "en": "TODO"
+      },
+      "options": [
+        {
+          "label": {
+            "it": "in chiaro",
+            "en": "cleartext"
+          },
+          "value": "CLEARTEXT"
+        },
+        {
+          "label": {
+            "it": "in forma pseudoanonimizzata",
+            "en": "pseudonymized"
+          },
+          "value": "PSEUDOANONYMOUS"
+        },
+        {
+          "label": {
+            "it": "in forma aggregata",
+            "en": "aggregated"
+          },
+          "value": "AGGREGATE"
+        },
+        {
+          "label": {
+            "it": "in forma anonimizzata",
+            "en": "anonymized"
+          },
+          "value": "ANONYMOUS"
+        }
+      ],
+      "defaultValue": "CLEARTEXT",
+      "required": true,
+      "dependencies": []
+    },
+    {
+      "id": "policyProvided",
+      "type": "radio",
+      "dataType": "single",
+      "label": {
+        "it": "Indicare se è stata fornita un’informativa all’interessato circa l’accesso ai dati cui si intende accedere/che si intende ricevere tramite la fruizione dell’E-Service e le relative attività di trattamento effettuate dal Fruitore: (richiesto)",
+        "en": "TODO (required)"
+      },
+      "options": [
+        {
+          "label": { "it": "Sì", "en": "Yes" },
+          "value": "YES"
+        },
+        {
+          "label": { "it": "No", "en": "No" },
+          "value": "NO"
+        }
+      ],
+      "defaultValue": "YES",
+      "required": true,
+      "dependencies": []
+    },
+    {
+      "id": "reasonPolicyNotProvided",
+      "type": "text",
+      "dataType": "freeText",
+      "label": {
+        "it": "Inserire le ragioni per cui non è stata fornita informativa specifica ai sensi dell’art. 14, paragrafo 5, del GDPR (richiesto)",
+        "en": "TODO (required)"
+      },
+      "infoLabel": {
+        "it": "Di norma sì fornisce un’informativa all’interessato circa l’accesso ai dati cui si intende accedere/che si intende ricevere tramite la fruizione dell’E-Service e le relative attività di trattamento effettuate dal Fruitore",
+        "en": "TODO"
+      },
+      "defaultValue": "",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "policyProvided",
+          "value": "NO"
+        }
+      ]
+    },
+    {
+      "id": "confirmPricipleIntegrityAndDiscretion",
+      "type": "switch",
+      "dataType": "single",
+      "label": {
+        "it": "Confermare se - in linea con il principio di integrità e riservatezza di cui all’art. 5, paragrafo 1, lett. f), del GDPR - sono state adottate tutte le misure tecniche e organizzative necessarie a garantire un’adeguata sicurezza dei dati personali cui si avrà accesso in sede di fruizione del presente E-service, compresa la protezione da trattamenti non autorizzati o illeciti e dalla perdita, dalla distruzione o dal danno accidentali. (richiesto)",
+        "en": "TODO (required)"
+      },
+      "options": [
+        {
+          "label": {"it": "Confermo", "en": "Confirm"},
+          "value": true
+        },
+        {
+          "label": {"it": "Nego", "en": "Deny"},
+          "value": false,
+          "forceUserCheckEServiceCatalog": true
+        }
+      ],
+      "defaultValue": false,
+      "required": true,
+      "dependencies": []
+    },
+    {
+      "id": "doneDpia",
+      "type": "radio",
+      "dataType": "single",
+      "label": {
+        "it": "Indicare se è stata fatta un’apposita Valutazione di Impatto (c.d. DPIA) relativamente alle attività di trattamento dei dati personali che saranno effettuate attraverso la fruizione del presente E-service (richiesto)",
+        "en": "TODO (required)"
+      },
+      "infoLabel": {
+        "it": "Se la risposta a questa domanda è no, si ricorda che la valutazione di impatto è obbligatoria ​​qualora sussistano le condizioni di cui all’art. 35 del GDPR.",
+        "en": "TODO"
+      },
+      "options": [
+        {
+          "label": { "it": "Sì", "en": "Yes" },
+          "value": "YES"
+        },
+        {
+          "label": { "it": "No", "en": "No" },
+          "value": "NO"
+        }
+      ],
+      "defaultValue": "NO",
+      "required": true,
+      "dependencies": []
+    },
+    {
+      "id": "confirmedDoneDpia",
+      "type": "radio",
+      "dataType": "single",
+      "label": {
+        "it": "Indicare se si è proceduto alla consultazione preventiva al Garante per la protezione dei dati personali (richiesto)",
+        "en": "TODO"
+      },
+      "infoLabel": {
+        "it": "Se la risposta a questa domanda è no, si ricorda che la consultazione preventiva è obbligatoria ​​qualora sussistano le condizioni di cui all’art. 36 del GDPR.",
+        "en": "TODO"
+      },
+      "options": [
+        {
+          "label": { "it": "Sì", "en": "Yes" },
+          "value": "YES"
+        },
+        {
+          "label": { "it": "No", "en": "No" },
+          "value": "NO"
+        }
+      ],
+      "defaultValue": "NO",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "doneDpia",
+          "value": "YES"
+        }
+      ]
+    },
+    {
+      "id": "dataRetentionPeriod",
+      "type": "switch",
+      "dataType": "single",
+      "label": {
+        "it": "In caso di download dei dati cui si avrà accesso attraverso il presente E-service, dichiarare se è stato individuato un periodo di conservazione dei dati (richiesto)",
+        "en": "TODO (required)"
+      },
+      "infoLabel": {
+        "it": "NB: si ricorda che il download del dato non consente di disporre di un dato aggiornato, e quindi di agire nel rispetto del principio di esattezza dei dati di cui all’art. 5, paragrafo 1, lettera d), del GDPR. Pertanto, si invita a limitare i casi di download del dato alle ipotesi in cui tale download è strettamente necessario e giustificato dalla finalità del trattamento. Si ricorda, altresì, che, ai sensi dell’art. 5, paragrafo 1, lett. b) ed e) del GDPR (principio della limitazione della finalità e della conservazione) , i dati possono essere conservati unicamente per il tempo strettamente necessario al perseguimento delle finalità per cui sono stati raccolti, e che le stesse siano determinate, esplicite e legittime.",
+        "en": "TODO"
+      },
+      "options": [
+        {
+          "label": {"it": "Confermo", "en": "Confirm"},
+          "value": true
+        },
+        {
+          "label": {"it": "Nego", "en": "Deny"},
+          "value": false,
+          "forceUserCheckEServiceCatalog": true
+        }
+      ],
+      "defaultValue": false,
+      "required": true,
+      "dependencies": []
+    },
+    {
+      "id": "purposePursuit",
+      "type": "radio",
+      "dataType": "single",
+      "label": {
+        "it": "Ai sensi del principio di minimizzazione di cui all’art. 5, paragrafo 1, let. c) del GDPR, per perseguire la finalità di cui al punto 1, indicare se (richiesto)",
+        "en": "TODO"
+      },
+      "options": [
+        {
+          "label": {
+            "it": "è sufficiente che l’Erogatore verifichi la mera correttezza di una/o determinata/o informazione/dato personale già in suo possesso",
+            "en": "it is sufficient for the Provider to check the mere correctedness of a particular information or personal data they already own"
+          },
+          "value": "MERE_CORRECTNESS"
+        },
+        {
+          "label": {
+            "it": "è necessario ricevere ex novo una/o determinata/o informazione/dato personale",
+            "en": "it is necessary to receive the information or personal data ex novo"
+          },
+          "value": "NEW_PERSONAL_DATA"
+        }
+      ],
+      "defaultValue": "MERE_CORRECTNESS",
+      "required": true,
+      "dependencies": []
+    },
+    {
+      "id": "checkedExistenceMereCorrectnessInteropCatalogue",
+      "type": "switch",
+      "dataType": "single",
+      "label": {
+        "it": "Confermare se è stato verificato se sul Catalogo API è presente un altro E-Service in grado di svolgere questa attività di mera verifica (che non preveda ex novo la comunicazione di altri informazioni/dati personali – richiesto)",
+        "en": "Have you checked if there is another E-Service in the Catalog that allows you to carry out this simple check task (in case it does not require the ex novo transmission of other information/personal data)? (required)"
+      },
+      "options": [
+        {
+          "label": {"it": "Confermo", "en": "Confirm"},
+          "value": true
+        },
+        {
+          "label": {"it": "Nego", "en": "Deny"},
+          "value": false,
+          "forceUserCheckEServiceCatalog": true,
+          "blockedAlert": {
+            "it": "Prima di procedere con l’invio della richiesta di accesso al presente E-service per la finalità indicata al punto 1, si invita a verificare se sul Catalogo API è presente un altro E-service che consenta di svolgere la mera attività di verifica di informazioni/dati personali di cui si necessita",
+            "en": "TODO"
+          }
+        }
+      ],
+      "defaultValue": false,
+      "required": true,
+      "dependencies": [
+        {
+          "id": "purposePursuit",
+          "value": "MERE_CORRECTNESS"
+        }
+      ]
+    },
+    {
+      "id": "checkedAllDataNeeded",
+      "type": "radio",
+      "dataType": "single",
+      "label": {
+        "it": "Indicare se è stato verificato se occorrono necessariamente tutte le informazioni e i dati personali messi a disposizione con il presente E-service (richiesto)",
+        "en": "TODO"
+      },
+      "infoLabel": {
+        "it": "Se la risposta a questa domanda è no, si invita a verificare se sul Catalogo API è presente un altro E-service che consenta di accedere alle sole informazioni/dati personali di cui si necessita.",
+        "en": "TODO"
+      },
+      "options": [
+        {
+          "label": { "it": "Sì", "en": "Yes" },
+          "value": "YES"
+        },
+        {
+          "label": { "it": "No", "en": "No" },
+          "value": "NO",
+          "forceUserCheckEServiceCatalog": true,
+          "blockedAlert": {
+            "it": "Prima di procedere con l’invio della richiesta di accesso al presente E-service per la finalità indicata al punto 1, si invita a verificare se sul Catalogo API è presente un altro E-service che consenta di accedere alle sole informazioni/dati personali di si necessita",
+            "en": "TODO"
+          }
+        }
+      ],
+      "defaultValue": "NO",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "purposePursuit",
+          "value": "NEW_PERSONAL_DATA"
+        }
+      ]
+    },
+    {
+      "id": "usesThirdPartyData",
+      "type": "radio",
+      "dataType": "single",
+      "label": {
+        "it": "Indicare se si accede a dati su richiesta/per conto di terzi soggetti (richiesto)",
+        "en": "TODO"
+      },
+      "options": [
+        {
+          "label": { "it": "Sì", "en": "Yes" },
+          "value": "YES"
+        },
+        {
+          "label": { "it": "No", "en": "No" },
+          "value": "NO"
+        }
+      ],
+      "defaultValue": "NO",
+      "required": true,
+      "dependencies": []
+    },
+    {
+      "id": "doesUseThirdPartyData",
+      "type": "radio",
+      "dataType": "single",
+      "label": {
+        "it": "Indicare se si accede a dati per conto di un soggetto di cui all’art. 2, comma 2, lett. a) del CAD (richiesto)",
+        "en": "TODO"
+      },
+      "options": [
+        {
+          "label": { "it": "Sì", "en": "Yes" },
+          "value": "YES"
+        },
+        {
+          "label": { "it": "No", "en": "No" },
+          "value": "NO"
+        }
+      ],
+      "defaultValue": "NO",
+      "required": true,
+      "dependencies": [
+        {
+          "id": "usesThirdPartyData",
+          "value": "YES"
+        }
+      ]
+    },
+    {
+      "id": "declarationConfirmGDPR",
+      "type": "switch",
+      "dataType": "single",
+      "label": {
+        "it": "Dichiara di essere consapevole degli obblighi di cui al GDPR in tema di trattamento di dati personali e ​​dichiara di essere in grado di comprovarne il rispetto (principio di responsabilizzazione di cui all’art. 5, paragrafo 2, del GDPR). (richiesto)",
+        "en": "TODO"
+      },
+      "options": [
+        {
+          "label": {"it": "Confermo", "en": "Confirm"},
+          "value": true
+        },
+        {
+          "label": {"it": "Nego", "en": "Deny"},
+          "value": false
+        }
+      ],
+      "defaultValue": false,
+      "required": true,
+      "dependencies": []
+    }
+  ]
+}

--- a/src/main/scala/it/pagopa/interop/purposeprocess/api/converters/purposemanagement/PurposeConverter.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/api/converters/purposemanagement/PurposeConverter.scala
@@ -9,20 +9,19 @@ object PurposeConverter {
     eService: EService,
     agreement: Agreement,
     clients: Seq[Client]
-  ): Purpose =
-    Purpose(
-      id = purpose.id,
-      agreement = agreement,
-      eservice = eService,
-      clients = clients,
-      consumerId = purpose.consumerId,
-      versions = purpose.versions.map(PurposeVersionConverter.dependencyToApi),
-      suspendedByConsumer = purpose.suspendedByConsumer,
-      suspendedByProducer = purpose.suspendedByProducer,
-      title = purpose.title,
-      riskAnalysisForm = purpose.riskAnalysisForm.map(RiskAnalysisConverter.dependencyToApi),
-      description = purpose.description,
-      createdAt = purpose.createdAt,
-      updatedAt = purpose.updatedAt
-    )
+  ): Purpose = Purpose(
+    id = purpose.id,
+    agreement = agreement,
+    eservice = eService,
+    clients = clients,
+    consumerId = purpose.consumerId,
+    versions = purpose.versions.map(PurposeVersionConverter.dependencyToApi),
+    suspendedByConsumer = purpose.suspendedByConsumer,
+    suspendedByProducer = purpose.suspendedByProducer,
+    title = purpose.title,
+    riskAnalysisForm = purpose.riskAnalysisForm.map(RiskAnalysisConverter.dependencyToApi),
+    description = purpose.description,
+    createdAt = purpose.createdAt,
+    updatedAt = purpose.updatedAt
+  )
 }

--- a/src/main/scala/it/pagopa/interop/purposeprocess/api/converters/purposemanagement/PurposeConverter.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/api/converters/purposemanagement/PurposeConverter.scala
@@ -1,6 +1,5 @@
 package it.pagopa.interop.purposeprocess.api.converters.purposemanagement
 
-import cats.implicits._
 import it.pagopa.interop.purposemanagement.client.model.{Purpose => DependencyPurpose}
 import it.pagopa.interop.purposeprocess.model.{Agreement, Client, EService, Purpose}
 
@@ -10,10 +9,8 @@ object PurposeConverter {
     eService: EService,
     agreement: Agreement,
     clients: Seq[Client]
-  ): Either[Throwable, Purpose] = {
-    for {
-      riskAnalysisForm <- purpose.riskAnalysisForm.traverse(RiskAnalysisConverter.dependencyToApi)
-    } yield Purpose(
+  ): Purpose =
+    Purpose(
       id = purpose.id,
       agreement = agreement,
       eservice = eService,
@@ -23,10 +20,9 @@ object PurposeConverter {
       suspendedByConsumer = purpose.suspendedByConsumer,
       suspendedByProducer = purpose.suspendedByProducer,
       title = purpose.title,
-      riskAnalysisForm = riskAnalysisForm,
+      riskAnalysisForm = purpose.riskAnalysisForm.map(RiskAnalysisConverter.dependencyToApi),
       description = purpose.description,
       createdAt = purpose.createdAt,
       updatedAt = purpose.updatedAt
     )
-  }
 }

--- a/src/main/scala/it/pagopa/interop/purposeprocess/api/converters/purposemanagement/RiskAnalysisConverter.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/api/converters/purposemanagement/RiskAnalysisConverter.scala
@@ -5,112 +5,19 @@ import it.pagopa.interop.purposemanagement.client.model.{
   RiskAnalysisMultiAnswer => DepRiskAnalysisMultiAnswer,
   RiskAnalysisSingleAnswer => DepRiskAnalysisSingleAnswer
 }
-import it.pagopa.interop.purposeprocess.api.impl.ValidationRules
-import it.pagopa.interop.purposeprocess.model.{
-  FormDataQuantityAnswers,
-  FormDeliveryMethodAnswers,
-  FormLegalBasisAnswers,
-  FormPurposePursuitAnswers,
-  RiskAnalysisForm,
-  RiskAnalysisFormAnswers,
-  RiskAnalysisFormYesAnswer,
-  RiskAnalysisFormYesNoAnswer
-}
-import cats.implicits._
+import it.pagopa.interop.purposeprocess.model.RiskAnalysisForm
 
 object RiskAnalysisConverter {
-  def dependencyToApi(riskAnalysis: DepRiskAnalysis): Either[Throwable, RiskAnalysisForm] = {
-    for {
-      answers <- answersToApi(riskAnalysis.singleAnswers, riskAnalysis.multiAnswers)
-    } yield RiskAnalysisForm(version = riskAnalysis.version, answers = answers)
-  }
-
-  def answersToApi(
-    singleAnswers: Seq[DepRiskAnalysisSingleAnswer],
-    multiAnswers: Seq[DepRiskAnalysisMultiAnswer]
-  ): Either[Throwable, RiskAnalysisFormAnswers] = {
-    for {
-      purposeOpt          <- toSingleAnswer(singleAnswers, ValidationRules.PURPOSE, Right(_))
-      purpose             <- purposeOpt.toRight(new RuntimeException(""))
-      usesPersonalDataOpt <- toYesNoSingleAnswer(singleAnswers, ValidationRules.USES_PERSONAL_DATA)
-      usesPersonalData    <- usesPersonalDataOpt.toRight(new RuntimeException(""))
-
-      usesThirdPartyPersonalData  <- toYesNoSingleAnswer(singleAnswers, ValidationRules.USES_THIRD_PARTY_PERSONAL_DATA)
-      usesConfidentialData        <- toYesNoSingleAnswer(singleAnswers, ValidationRules.USES_CONFIDENTIAL_DATA)
-      securedDataAccess           <- toYesNoSingleAnswer(singleAnswers, ValidationRules.SECURED_DATA_ACCESS)
-      legalObligationReference    <- toSingleAnswer(singleAnswers, ValidationRules.LEGAL_OBLIGATION_REFERENCE, Right(_))
-      publicInterestReference     <- toSingleAnswer(singleAnswers, ValidationRules.PUBLIC_INTEREST_REFERENCE, Right(_))
-      knowsAccessedDataCategories <- toYesNoSingleAnswer(singleAnswers, ValidationRules.KNOWS_ACCESSED_DATA_CATEGORIES)
-      accessDataArt9Gdpr          <- toYesNoSingleAnswer(singleAnswers, ValidationRules.ACCESS_DATA_ART9_GDPR)
-      accessUnderageData          <- toYesNoSingleAnswer(singleAnswers, ValidationRules.ACCESS_UNDERAGE_DATA)
-      knowsDataQuantity           <- toYesNoSingleAnswer(singleAnswers, ValidationRules.KNOWS_DATA_QUANTITY)
-      dataQuantity   <- toSingleAnswer(singleAnswers, ValidationRules.DATA_QUANTITY, FormDataQuantityAnswers.fromValue)
-      deliveryMethod <- toSingleAnswer(
-        singleAnswers,
-        ValidationRules.DELIVERY_METHOD,
-        FormDeliveryMethodAnswers.fromValue
-      )
-      doneDpia       <- toYesNoSingleAnswer(singleAnswers, ValidationRules.DONE_DPIA)
-      definedDataRetentionPeriod  <- toYesNoSingleAnswer(singleAnswers, ValidationRules.DEFINED_DATA_RETENTION_PERIOD)
-      purposePursuit              <- toSingleAnswer(
-        singleAnswers,
-        ValidationRules.PURPOSE_PURSUIT,
-        FormPurposePursuitAnswers.fromValue
-      )
-      checkedAllDataNeeded        <- toYesNoSingleAnswer(singleAnswers, ValidationRules.CHECKED_ALL_DATA_NEEDED)
-      minimalDataInteropCatalogue <- toYesNoSingleAnswer(
-        singleAnswers,
-        ValidationRules.CHECKED_EXISTENCE_MINIMAL_DATA_INTEROP_CATALOGUE
-      )
-      legalBasis <- toMultiAnswer(multiAnswers, ValidationRules.LEGAL_BASIS, FormLegalBasisAnswers.fromValue)
-      mereCorrectnessInteropCatalogue <- toMultiAnswer(
-        multiAnswers,
-        ValidationRules.CHECKED_EXISTENCE_MERE_CORRECTNESS_INTEROP_CATALOGUE,
-        RiskAnalysisFormYesAnswer.fromValue
-      )
-    } yield RiskAnalysisFormAnswers(
-      purpose = purpose,
-      usesPersonalData = usesPersonalData,
-      usesThirdPartyPersonalData = usesThirdPartyPersonalData,
-      usesConfidentialData = usesConfidentialData,
-      securedDataAccess = securedDataAccess,
-      legalBasis = legalBasis,
-      legalObligationReference = legalObligationReference,
-      publicInterestReference = publicInterestReference,
-      knowsAccessedDataCategories = knowsAccessedDataCategories,
-      accessDataArt9Gdpr = accessDataArt9Gdpr,
-      accessUnderageData = accessUnderageData,
-      knowsDataQuantity = knowsDataQuantity,
-      dataQuantity = dataQuantity,
-      deliveryMethod = deliveryMethod,
-      doneDpia = doneDpia,
-      definedDataRetentionPeriod = definedDataRetentionPeriod,
-      purposePursuit = purposePursuit,
-      checkedExistenceMereCorrectnessInteropCatalogue = mereCorrectnessInteropCatalogue,
-      checkedAllDataNeeded = checkedAllDataNeeded,
-      checkedExistenceMinimalDataInteropCatalogue = minimalDataInteropCatalogue
+  def dependencyToApi(riskAnalysis: DepRiskAnalysis): RiskAnalysisForm =
+    RiskAnalysisForm(
+      version = riskAnalysis.version,
+      answers = singleAnswersToApi(riskAnalysis.singleAnswers) ++ multiAnswersToApi(riskAnalysis.multiAnswers)
     )
-  }
 
-  def toYesNoSingleAnswer(
-    singleAnswers: Seq[DepRiskAnalysisSingleAnswer],
-    fieldName: String
-  ): Either[Throwable, Option[RiskAnalysisFormYesNoAnswer]] =
-    toSingleAnswer(singleAnswers, fieldName, RiskAnalysisFormYesNoAnswer.fromValue)
+  def singleAnswersToApi(singleAnswers: Seq[DepRiskAnalysisSingleAnswer]): Map[String, Seq[String]] =
+    singleAnswers.map(a => (a.key, a.value.toSeq)).toMap
 
-  def toSingleAnswer[T](
-    singleAnswers: Seq[DepRiskAnalysisSingleAnswer],
-    fieldName: String,
-    f: String => Either[Throwable, T]
-  ): Either[Throwable, Option[T]] =
-    singleAnswers.find(_.key == fieldName).flatTraverse(_.value.traverse(f))
+  def multiAnswersToApi(multiAnswers: Seq[DepRiskAnalysisMultiAnswer]): Map[String, Seq[String]] =
+    multiAnswers.map(a => (a.key, a.values)).toMap
 
-  def toMultiAnswer[T](
-    multiAnswers: Seq[DepRiskAnalysisMultiAnswer],
-    fieldName: String,
-    f: String => Either[Throwable, T]
-  ): Either[Throwable, Option[Seq[T]]] =
-    multiAnswers
-      .find(_.key == fieldName)
-      .traverse(_.values.traverse(f))
 }

--- a/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/PurposeApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/PurposeApiServiceImpl.scala
@@ -600,10 +600,8 @@ final case class PurposeApiServiceImpl(
       producer  = OrganizationConverter.dependencyToApi(depProducer)
       eService <- EServiceConverter.dependencyToApi(depEService, depAgreement.descriptorId, producer).toFuture
       clients  <- clientsByUserType()
-      purpose  <- PurposeConverter
-        .dependencyToApi(purpose = depPurpose, eService = eService, agreement = agreement, clients = clients)
-        .toFuture
-    } yield purpose
+    } yield PurposeConverter
+      .dependencyToApi(purpose = depPurpose, eService = eService, agreement = agreement, clients = clients)
   }
 
   def handleApiError(

--- a/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/RiskAnalysisValidation.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/RiskAnalysisValidation.scala
@@ -202,12 +202,11 @@ object RiskAnalysisValidation {
 
   def jsArrayIsSubset(fieldName: String, arr: JsArray, values: Set[String]): ValidationResult[Unit] =
     arr.elements
-      .map {
+      .traverse {
         case v: JsString if values.contains(v.value) => ().validNec
         case _                                       => UnexpectedFieldValue(fieldName, values.some).invalidNec
       }
-      .sequence
-      .map(_ => ())
+      .as(())
 
   def dependencyConfigToRule(dependency: Dependency): DependencyEntry =
     DependencyEntry(fieldName = dependency.id, fieldValue = dependency.value)

--- a/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/RiskAnalysisValidation.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/RiskAnalysisValidation.scala
@@ -9,6 +9,7 @@ import it.pagopa.interop.purposemanagement.client.model.{
 }
 import it.pagopa.interop.purposeprocess.error._
 import it.pagopa.interop.purposeprocess.model._
+import it.pagopa.interop.purposeprocess.model.riskAnalysisRules.{DependencyEntry, ValidationEntry}
 import it.pagopa.interop.purposeprocess.model.riskAnalysisTemplate._
 import it.pagopa.interop.purposeprocess.service.RiskAnalysisService
 import spray.json._
@@ -151,7 +152,7 @@ object RiskAnalysisValidation {
     validationRules.find(_.fieldName == fieldName) match {
       case Some(rule) =>
         validateAllowedValue(rule, value)
-          .andThen(_ => rule.dependencies.map(validateDependency(answersJson, rule.fieldName)).sequence)
+          .andThen(_ => rule.dependencies.traverse(validateDependency(answersJson, rule.fieldName)))
           .as(rule)
       case None       =>
         UnexpectedField(fieldName).invalidNec
@@ -243,12 +244,3 @@ object RiskAnalysisValidation {
     config.questions.map(questionToValidationEntry)
 
 }
-
-final case class DependencyEntry(fieldName: String, fieldValue: String)
-final case class ValidationEntry(
-  fieldName: String,
-  dataType: DataType,
-  required: Boolean,
-  dependencies: Seq[DependencyEntry],
-  allowedValues: Option[Set[String]]
-)

--- a/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/RiskAnalysisValidation.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/RiskAnalysisValidation.scala
@@ -201,12 +201,10 @@ object RiskAnalysisValidation {
     arr.elements.collectFirst { case v: JsString if v.value == value => () }.nonEmpty
 
   def jsArrayIsSubset(fieldName: String, arr: JsArray, values: Set[String]): ValidationResult[Unit] =
-    arr.elements
-      .traverse {
-        case v: JsString if values.contains(v.value) => ().validNec
-        case _                                       => UnexpectedFieldValue(fieldName, values.some).invalidNec
-      }
-      .as(())
+    arr.elements.traverse {
+      case v: JsString if values.contains(v.value) => ().validNec
+      case _                                       => UnexpectedFieldValue(fieldName, values.some).invalidNec
+    }.void
 
   def dependencyConfigToRule(dependency: Dependency): DependencyEntry =
     DependencyEntry(fieldName = dependency.id, fieldValue = dependency.value)

--- a/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/RiskAnalysisValidation.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/RiskAnalysisValidation.scala
@@ -3,13 +3,16 @@ package it.pagopa.interop.purposeprocess.api.impl
 import cats.data._
 import cats.implicits._
 import it.pagopa.interop.purposemanagement.client.model.{
-  RiskAnalysisFormSeed => RiskAnalysisFormSeed,
+  RiskAnalysisFormSeed,
   RiskAnalysisMultiAnswerSeed => MultiAnswerSeed,
   RiskAnalysisSingleAnswerSeed => SingleAnswerSeed
 }
 import it.pagopa.interop.purposeprocess.error._
 import it.pagopa.interop.purposeprocess.model._
+import it.pagopa.interop.purposeprocess.model.riskAnalysisTemplate._
 import spray.json._
+
+import scala.io.Source
 
 object RiskAnalysisValidation {
 
@@ -21,15 +24,19 @@ object RiskAnalysisValidation {
     */
   def validate(form: RiskAnalysisForm): ValidationResult[RiskAnalysisFormSeed] = {
 
+    val configs1_0 = loadRiskAnalysisFormConfig("riskAnalysisTemplate/forms/1.0.json")
+    val configs2_0 = loadRiskAnalysisFormConfig("riskAnalysisTemplate/forms/2.0.json")
+
+    val sanitizedForm = form.copy(answers = form.answers.filter(_._2.nonEmpty))
     // TODO Test this
-    val validationRules: ValidationResult[List[ValidationEntry]] = form.version match {
+    val validationRules: ValidationResult[List[ValidationEntry]] = sanitizedForm.version match {
       // TODO Enum?
-      case "1.0" => ValidationRulesV1.validationRules.validNec
-      case "2.0" => ValidationRulesV2.validationRules.validNec
+      case "1.0" => configsToRules(configs1_0).validNec
+      case "2.0" => configsToRules(configs2_0).validNec
       case other => UnexpectedTemplateVersion(other).invalidNec
     }
 
-    validationRules.andThen(validateFormWithRules(_, form))
+    validationRules.andThen(validateFormWithRules(_, sanitizedForm))
 
   }
 
@@ -100,7 +107,7 @@ object RiskAnalysisValidation {
     answersJson.fields.map { case (key, value) =>
       validateField(answersJson, validationRules)(key, value).fold(
         err => Left[ValidationResult[SingleAnswerSeed], Nothing](err.invalid),
-        _ => answerToDependency(key, value)
+        rule => answerToDependency(rule, key, value)
       )
     }.toSeq
   }
@@ -111,13 +118,22 @@ object RiskAnalysisValidation {
     * @return Either for the validation of the SingleAnswer (Left) or MultiAnswer (Right)
     */
   def answerToDependency(
+    rule: ValidationEntry,
     fieldName: String,
     value: JsValue
   ): Either[ValidationResult[SingleAnswerSeed], ValidationResult[MultiAnswerSeed]] =
     value match {
-      case str: JsString =>
-        Left(SingleAnswerSeed(fieldName, Some(str.value)).validNec[RiskAnalysisValidationError])
-      case arr: JsArray  =>
+//      case str: JsString =>
+//        Left(SingleAnswerSeed(fieldName, Some(str.value)).validNec[RiskAnalysisValidationError])
+      case arr: JsArray if rule.dataType == "single" || rule.dataType == "freeText" =>
+        val value: ValidationResult[String] = {
+          arr.elements.headOption match {
+            case Some(str: JsString) => str.value.validNec
+            case _                   => UnexpectedFieldFormat(fieldName).invalidNec
+          }
+        }
+        Left(value.map(v => SingleAnswerSeed(fieldName, v.some)))
+      case arr: JsArray if rule.dataType == "multi"                                 =>
         val values: Seq[ValidationResult[String]] = {
           arr.elements.map {
             case str: JsString => str.value.validNec
@@ -125,7 +141,7 @@ object RiskAnalysisValidation {
           }
         }
         Right(values.sequence.map(MultiAnswerSeed(fieldName, _)))
-      case _             =>
+      case _                                                                        =>
         Left(UnexpectedFieldFormat(fieldName).invalidNec)
     }
 
@@ -138,12 +154,12 @@ object RiskAnalysisValidation {
   def validateField(
     answersJson: JsObject,
     validationRules: List[ValidationEntry]
-  )(fieldName: String, value: JsValue): ValidationResult[Seq[Unit]] =
+  )(fieldName: String, value: JsValue): ValidationResult[ValidationEntry] =
     validationRules.find(_.fieldName == fieldName) match {
       case Some(rule) =>
-        validateAllowedValue(rule, value).andThen(_ =>
-          rule.dependencies.map(validateDependency(answersJson, rule.fieldName)).sequence
-        )
+        validateAllowedValue(rule, value)
+          .andThen(_ => rule.dependencies.map(validateDependency(answersJson, rule.fieldName)).sequence)
+          .as(rule)
       case None       =>
         UnexpectedField(fieldName).invalidNec
     }
@@ -199,238 +215,281 @@ object RiskAnalysisValidation {
       .sequence
       .map(_ => ())
 
+  private[this] def loadRiskAnalysisFormConfig(resourcePath: String) =
+    Source
+      .fromResource(resourcePath)
+      .getLines()
+      .mkString(System.lineSeparator())
+      .parseJson
+      .convertTo[RiskAnalysisFormConfig]
+
+  def dependencyConfigToRule(dependency: Dependency): DependencyEntry =
+    DependencyEntry(fieldName = dependency.id, fieldValue = dependency.value)
+
+  def questionToValidationEntry(question: FormConfigQuestion): ValidationEntry =
+    question match {
+      case c: FreeInputQuestion =>
+        ValidationEntry(
+          fieldName = c.id,
+          dataType = c.dataType,
+          required = c.required,
+          dependencies = c.dependencies.map(dependencyConfigToRule),
+          allowedValues = None
+        )
+      case c: SingleQuestion    =>
+        ValidationEntry(
+          fieldName = c.id,
+          dataType = c.dataType,
+          required = c.required,
+          dependencies = c.dependencies.map(dependencyConfigToRule),
+          allowedValues = c.options.map(_.value).toSet.some
+        )
+      case c: MultiQuestion     =>
+        ValidationEntry(
+          fieldName = c.id,
+          dataType = c.dataType,
+          required = c.required,
+          dependencies = c.dependencies.map(dependencyConfigToRule),
+          allowedValues = c.options.map(_.value).toSet.some
+        )
+    }
+
+  def configsToRules(config: RiskAnalysisFormConfig): List[ValidationEntry] =
+    config.questions.map(questionToValidationEntry)
+
 }
 
 final case class DependencyEntry(fieldName: String, fieldValue: String)
 final case class ValidationEntry(
   fieldName: String,
+  dataType: String, // TODO Enum?
   required: Boolean,
   dependencies: Seq[DependencyEntry],
   allowedValues: Option[Set[String]]
 )
 
-// TODO Move to different file
-object ValidationRulesV1 {
-
-  // Answers
-  object YesNoAnswer extends Enumeration {
-    type YesNoAnswer = Value
-    val YES, NO                = Value
-    val valuesSet: Set[String] = values.map(_.toString)
-  }
-
-  val YES: String = YesNoAnswer.YES.toString
-  val NO: String  = YesNoAnswer.NO.toString
-
-  object LegalBasisAnswer extends Enumeration {
-    type FormLegalBasisAnswers = Value
-    val CONSENT, CONTRACT, LEGAL_OBLIGATION, SAFEGUARD, PUBLIC_INTEREST, LEGITIMATE_INTEREST = Value
-    val valuesSet: Set[String]                                                               = values.map(_.toString)
-  }
-
-  object DataQuantityAnswer extends Enumeration {
-    type FormDataQuantityAnswers = Value
-    val QUANTITY_0_TO_100, QUANTITY_101_TO_500, QUANTITY_500_TO_1000, QUANTITY_1001_TO_5000, QUANTITY_5001_OVER = Value
-    val valuesSet: Set[String] = values.map(_.toString)
-  }
-
-  object DeliveryMethodAnswer extends Enumeration {
-    type FormDeliveryMethodAnswers = Value
-    val CLEARTEXT, AGGREGATE, ANONYMOUS, PSEUDOANONYMOUS = Value
-    val valuesSet: Set[String]                           = values.map(_.toString)
-  }
-
-  object PurposePursuitAnswer extends Enumeration {
-    type FormPurposePursuitAnswers = Value
-    val MERE_CORRECTNESS, NEW_PERSONAL_DATA = Value
-    val valuesSet: Set[String]              = values.map(_.toString)
-  }
-  // End Answers
-
-  // Fields names
-  val PURPOSE: String                                              = "purpose"
-  val ACCESS_DATA_ART9_GDPR: String                                = "accessDataArt9Gdpr"
-  val ACCESS_UNDERAGE_DATA: String                                 = "accessUnderageData"
-  val CHECKED_ALL_DATA_NEEDED: String                              = "checkedAllDataNeeded"
-  val CHECKED_EXISTENCE_MERE_CORRECTNESS_INTEROP_CATALOGUE: String = "checkedExistenceMereCorrectnessInteropCatalogue"
-  val CHECKED_EXISTENCE_MINIMAL_DATA_INTEROP_CATALOGUE: String     = "checkedExistenceMinimalDataInteropCatalogue"
-  val DATA_QUANTITY: String                                        = "dataQuantity"
-  val DEFINED_DATA_RETENTION_PERIOD: String                        = "definedDataRetentionPeriod"
-  val DELIVERY_METHOD: String                                      = "deliveryMethod"
-  val DONE_DPIA: String                                            = "doneDpia"
-  val KNOWS_ACCESSED_DATA_CATEGORIES: String                       = "knowsAccessedDataCategories"
-  val KNOWS_DATA_QUANTITY: String                                  = "knowsDataQuantity"
-  val LEGAL_BASIS: String                                          = "legalBasis"
-  val LEGAL_OBLIGATION_REFERENCE: String                           = "legalObligationReference"
-  val PUBLIC_INTEREST_REFERENCE: String                            = "publicInterestReference"
-  val PURPOSE_PURSUIT: String                                      = "purposePursuit"
-  val SECURED_DATA_ACCESS: String                                  = "securedDataAccess"
-  val USES_CONFIDENTIAL_DATA: String                               = "usesConfidentialData"
-  val USES_PERSONAL_DATA: String                                   = "usesPersonalData"
-  val USES_THIRD_PARTY_PERSONAL_DATA: String                       = "usesThirdPartyPersonalData"
-  // End Fields names
-
-  val validationRules: List[ValidationEntry] = List(
-    ValidationEntry(PURPOSE, required = true, Seq.empty, None),
-    ValidationEntry(USES_PERSONAL_DATA, required = true, Seq.empty, YesNoAnswer.valuesSet.some),
-    ValidationEntry(
-      USES_THIRD_PARTY_PERSONAL_DATA,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, NO)),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      USES_CONFIDENTIAL_DATA,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, NO), DependencyEntry(USES_THIRD_PARTY_PERSONAL_DATA, YES)),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      SECURED_DATA_ACCESS,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, NO)),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      LEGAL_BASIS,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      LEGAL_OBLIGATION_REFERENCE,
-      required = true,
-      Seq(DependencyEntry(LEGAL_BASIS, LegalBasisAnswer.LEGAL_OBLIGATION.toString)),
-      None
-    ),
-    ValidationEntry(
-      PUBLIC_INTEREST_REFERENCE,
-      required = true,
-      Seq(DependencyEntry(LEGAL_BASIS, LegalBasisAnswer.PUBLIC_INTEREST.toString)),
-      None
-    ),
-    ValidationEntry(
-      KNOWS_ACCESSED_DATA_CATEGORIES,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      ACCESS_DATA_ART9_GDPR,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, YES), DependencyEntry(KNOWS_ACCESSED_DATA_CATEGORIES, YES)),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      ACCESS_UNDERAGE_DATA,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, YES), DependencyEntry(KNOWS_ACCESSED_DATA_CATEGORIES, YES)),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      KNOWS_DATA_QUANTITY,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      DATA_QUANTITY,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, YES), DependencyEntry(KNOWS_DATA_QUANTITY, YES)),
-      DataQuantityAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      DELIVERY_METHOD,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
-      DeliveryMethodAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      DONE_DPIA,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      DEFINED_DATA_RETENTION_PERIOD,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      PURPOSE_PURSUIT,
-      required = true,
-      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
-      PurposePursuitAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      CHECKED_EXISTENCE_MERE_CORRECTNESS_INTEROP_CATALOGUE,
-      required = true,
-      Seq(
-        DependencyEntry(USES_PERSONAL_DATA, YES),
-        DependencyEntry(PURPOSE_PURSUIT, PurposePursuitAnswer.MERE_CORRECTNESS.toString)
-      ),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      CHECKED_ALL_DATA_NEEDED,
-      required = true,
-      Seq(
-        DependencyEntry(USES_PERSONAL_DATA, YES),
-        DependencyEntry(PURPOSE_PURSUIT, PurposePursuitAnswer.NEW_PERSONAL_DATA.toString)
-      ),
-      YesNoAnswer.valuesSet.some
-    ),
-    ValidationEntry(
-      CHECKED_EXISTENCE_MINIMAL_DATA_INTEROP_CATALOGUE,
-      required = true,
-      Seq(
-        DependencyEntry(USES_PERSONAL_DATA, YES),
-        DependencyEntry(PURPOSE_PURSUIT, PurposePursuitAnswer.NEW_PERSONAL_DATA.toString),
-        DependencyEntry(CHECKED_ALL_DATA_NEEDED, NO)
-      ),
-      YesNoAnswer.valuesSet.some
-    )
-  )
-}
-
-object ValidationRulesV2 {
-
-  // Answers
-  object YesNoAnswer extends Enumeration {
-    type YesNo = Value
-    val YES, NO = Value
-  }
-
-  val YES: String = YesNoAnswer.YES.toString
-  val NO: String  = YesNoAnswer.NO.toString
-
-  object FormLegalBasisAnswer extends Enumeration {
-    type FormLegalBasisAnswers = Value
-    val CONSENT, CONTRACT, LEGAL_OBLIGATION, SAFEGUARD, PUBLIC_INTEREST, LEGITIMATE_INTEREST = Value
-  }
-
-  object FormDataQuantityAnswer extends Enumeration {
-    type FormDataQuantityAnswers = Value
-    val QUANTITY_0_TO_100, QUANTITY_101_TO_500, QUANTITY_500_TO_1000, QUANTITY_1001_TO_5000, QUANTITY_5001_OVER = Value
-  }
-
-  object FormDeliveryMethodAnswer extends Enumeration {
-    type FormDeliveryMethodAnswers = Value
-    val CLEARTEXT, AGGREGATE, ANONYMOUS, PSEUDOANONYMOUS = Value
-  }
-
-  object FormPurposePursuitAnswer extends Enumeration {
-    type FormPurposePursuitAnswers = Value
-    val MERE_CORRECTNESS, NEW_PERSONAL_DATA = Value
-  }
-  // End Answers
-
-  // Fields names
-  val PURPOSE: String = "purpose"
-  // End Fields names
-
-  val validationRules: List[ValidationEntry] = List(
-    ValidationEntry(PURPOSE, required = true, Seq.empty),
-  )
-}
+//// TODO Move to different file
+//object ValidationRulesV1 {
+//
+//  // Answers
+//  object YesNoAnswer extends Enumeration {
+//    type YesNoAnswer = Value
+//    val YES, NO                = Value
+//    val valuesSet: Set[String] = values.map(_.toString)
+//  }
+//
+//  val YES: String = YesNoAnswer.YES.toString
+//  val NO: String  = YesNoAnswer.NO.toString
+//
+//  object LegalBasisAnswer extends Enumeration {
+//    type FormLegalBasisAnswers = Value
+//    val CONSENT, CONTRACT, LEGAL_OBLIGATION, SAFEGUARD, PUBLIC_INTEREST, LEGITIMATE_INTEREST = Value
+//    val valuesSet: Set[String]                                                               = values.map(_.toString)
+//  }
+//
+//  object DataQuantityAnswer extends Enumeration {
+//    type FormDataQuantityAnswers = Value
+//    val QUANTITY_0_TO_100, QUANTITY_101_TO_500, QUANTITY_500_TO_1000, QUANTITY_1001_TO_5000, QUANTITY_5001_OVER = Value
+//    val valuesSet: Set[String] = values.map(_.toString)
+//  }
+//
+//  object DeliveryMethodAnswer extends Enumeration {
+//    type FormDeliveryMethodAnswers = Value
+//    val CLEARTEXT, AGGREGATE, ANONYMOUS, PSEUDOANONYMOUS = Value
+//    val valuesSet: Set[String]                           = values.map(_.toString)
+//  }
+//
+//  object PurposePursuitAnswer extends Enumeration {
+//    type FormPurposePursuitAnswers = Value
+//    val MERE_CORRECTNESS, NEW_PERSONAL_DATA = Value
+//    val valuesSet: Set[String]              = values.map(_.toString)
+//  }
+//  // End Answers
+//
+//  // Fields names
+//  val PURPOSE: String                                              = "purpose"
+//  val ACCESS_DATA_ART9_GDPR: String                                = "accessDataArt9Gdpr"
+//  val ACCESS_UNDERAGE_DATA: String                                 = "accessUnderageData"
+//  val CHECKED_ALL_DATA_NEEDED: String                              = "checkedAllDataNeeded"
+//  val CHECKED_EXISTENCE_MERE_CORRECTNESS_INTEROP_CATALOGUE: String = "checkedExistenceMereCorrectnessInteropCatalogue"
+//  val CHECKED_EXISTENCE_MINIMAL_DATA_INTEROP_CATALOGUE: String     = "checkedExistenceMinimalDataInteropCatalogue"
+//  val DATA_QUANTITY: String                                        = "dataQuantity"
+//  val DEFINED_DATA_RETENTION_PERIOD: String                        = "definedDataRetentionPeriod"
+//  val DELIVERY_METHOD: String                                      = "deliveryMethod"
+//  val DONE_DPIA: String                                            = "doneDpia"
+//  val KNOWS_ACCESSED_DATA_CATEGORIES: String                       = "knowsAccessedDataCategories"
+//  val KNOWS_DATA_QUANTITY: String                                  = "knowsDataQuantity"
+//  val LEGAL_BASIS: String                                          = "legalBasis"
+//  val LEGAL_OBLIGATION_REFERENCE: String                           = "legalObligationReference"
+//  val PUBLIC_INTEREST_REFERENCE: String                            = "publicInterestReference"
+//  val PURPOSE_PURSUIT: String                                      = "purposePursuit"
+//  val SECURED_DATA_ACCESS: String                                  = "securedDataAccess"
+//  val USES_CONFIDENTIAL_DATA: String                               = "usesConfidentialData"
+//  val USES_PERSONAL_DATA: String                                   = "usesPersonalData"
+//  val USES_THIRD_PARTY_PERSONAL_DATA: String                       = "usesThirdPartyPersonalData"
+//  // End Fields names
+//
+//  val validationRules: List[ValidationEntry] = List(
+//    ValidationEntry(PURPOSE, required = true, Seq.empty, None),
+//    ValidationEntry(USES_PERSONAL_DATA, required = true, Seq.empty, YesNoAnswer.valuesSet.some),
+//    ValidationEntry(
+//      USES_THIRD_PARTY_PERSONAL_DATA,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, NO)),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      USES_CONFIDENTIAL_DATA,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, NO), DependencyEntry(USES_THIRD_PARTY_PERSONAL_DATA, YES)),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      SECURED_DATA_ACCESS,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, NO)),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      LEGAL_BASIS,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      LEGAL_OBLIGATION_REFERENCE,
+//      required = true,
+//      Seq(DependencyEntry(LEGAL_BASIS, LegalBasisAnswer.LEGAL_OBLIGATION.toString)),
+//      None
+//    ),
+//    ValidationEntry(
+//      PUBLIC_INTEREST_REFERENCE,
+//      required = true,
+//      Seq(DependencyEntry(LEGAL_BASIS, LegalBasisAnswer.PUBLIC_INTEREST.toString)),
+//      None
+//    ),
+//    ValidationEntry(
+//      KNOWS_ACCESSED_DATA_CATEGORIES,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      ACCESS_DATA_ART9_GDPR,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, YES), DependencyEntry(KNOWS_ACCESSED_DATA_CATEGORIES, YES)),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      ACCESS_UNDERAGE_DATA,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, YES), DependencyEntry(KNOWS_ACCESSED_DATA_CATEGORIES, YES)),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      KNOWS_DATA_QUANTITY,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      DATA_QUANTITY,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, YES), DependencyEntry(KNOWS_DATA_QUANTITY, YES)),
+//      DataQuantityAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      DELIVERY_METHOD,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
+//      DeliveryMethodAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      DONE_DPIA,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      DEFINED_DATA_RETENTION_PERIOD,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      PURPOSE_PURSUIT,
+//      required = true,
+//      Seq(DependencyEntry(USES_PERSONAL_DATA, YES)),
+//      PurposePursuitAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      CHECKED_EXISTENCE_MERE_CORRECTNESS_INTEROP_CATALOGUE,
+//      required = true,
+//      Seq(
+//        DependencyEntry(USES_PERSONAL_DATA, YES),
+//        DependencyEntry(PURPOSE_PURSUIT, PurposePursuitAnswer.MERE_CORRECTNESS.toString)
+//      ),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      CHECKED_ALL_DATA_NEEDED,
+//      required = true,
+//      Seq(
+//        DependencyEntry(USES_PERSONAL_DATA, YES),
+//        DependencyEntry(PURPOSE_PURSUIT, PurposePursuitAnswer.NEW_PERSONAL_DATA.toString)
+//      ),
+//      YesNoAnswer.valuesSet.some
+//    ),
+//    ValidationEntry(
+//      CHECKED_EXISTENCE_MINIMAL_DATA_INTEROP_CATALOGUE,
+//      required = true,
+//      Seq(
+//        DependencyEntry(USES_PERSONAL_DATA, YES),
+//        DependencyEntry(PURPOSE_PURSUIT, PurposePursuitAnswer.NEW_PERSONAL_DATA.toString),
+//        DependencyEntry(CHECKED_ALL_DATA_NEEDED, NO)
+//      ),
+//      YesNoAnswer.valuesSet.some
+//    )
+//  )
+//}
+//
+//object ValidationRulesV2 {
+//
+//  // Answers
+//  object YesNoAnswer extends Enumeration {
+//    type YesNo = Value
+//    val YES, NO = Value
+//  }
+//
+//  val YES: String = YesNoAnswer.YES.toString
+//  val NO: String  = YesNoAnswer.NO.toString
+//
+//  object FormLegalBasisAnswer extends Enumeration {
+//    type FormLegalBasisAnswers = Value
+//    val CONSENT, CONTRACT, LEGAL_OBLIGATION, SAFEGUARD, PUBLIC_INTEREST, LEGITIMATE_INTEREST = Value
+//  }
+//
+//  object FormDataQuantityAnswer extends Enumeration {
+//    type FormDataQuantityAnswers = Value
+//    val QUANTITY_0_TO_100, QUANTITY_101_TO_500, QUANTITY_500_TO_1000, QUANTITY_1001_TO_5000, QUANTITY_5001_OVER = Value
+//  }
+//
+//  object FormDeliveryMethodAnswer extends Enumeration {
+//    type FormDeliveryMethodAnswers = Value
+//    val CLEARTEXT, AGGREGATE, ANONYMOUS, PSEUDOANONYMOUS = Value
+//  }
+//
+//  object FormPurposePursuitAnswer extends Enumeration {
+//    type FormPurposePursuitAnswers = Value
+//    val MERE_CORRECTNESS, NEW_PERSONAL_DATA = Value
+//  }
+//  // End Answers
+//
+//  // Fields names
+//  val PURPOSE: String = "purpose"
+//  // End Fields names
+//
+//  val validationRules: List[ValidationEntry] = List(
+////    ValidationEntry(PURPOSE, required = true, Seq.empty),
+//  )
+//}

--- a/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/package.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/api/impl/package.scala
@@ -24,19 +24,17 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
   implicit def eServiceFormat: RootJsonFormat[EService]             = jsonFormat4(EService)
   implicit def agreementFormat: RootJsonFormat[Agreement]           = jsonFormat2(Agreement)
 
-  implicit def riskAnalysisFormAnswersFormat: RootJsonFormat[RiskAnalysisFormAnswers] =
-    jsonFormat20(RiskAnalysisFormAnswers)
-  implicit def riskAnalysisFormFormat: RootJsonFormat[RiskAnalysisForm]               = jsonFormat2(RiskAnalysisForm)
-  implicit def purposeVersionDocumentFormat: RootJsonFormat[PurposeVersionDocument]   =
+  implicit def riskAnalysisFormFormat: RootJsonFormat[RiskAnalysisForm]             = jsonFormat2(RiskAnalysisForm)
+  implicit def purposeVersionDocumentFormat: RootJsonFormat[PurposeVersionDocument] =
     jsonFormat3(PurposeVersionDocument)
-  implicit def purposeFormat: RootJsonFormat[Purpose]                                 = jsonFormat13(Purpose)
-  implicit def purposeVersionFormat: RootJsonFormat[PurposeVersion]                   = jsonFormat8(PurposeVersion)
-  implicit def purposesFormat: RootJsonFormat[Purposes]                               = jsonFormat1(Purposes)
-  implicit def purposeSeedFormat: RootJsonFormat[PurposeSeed]                         = jsonFormat5(PurposeSeed)
-  implicit def purposeUpdateContentFormat: RootJsonFormat[PurposeUpdateContent] = jsonFormat3(PurposeUpdateContent)
-  implicit def purposeVersionSeedFormat: RootJsonFormat[PurposeVersionSeed]     = jsonFormat1(PurposeVersionSeed)
-  implicit def problemErrorFormat: RootJsonFormat[ProblemError]                 = jsonFormat2(ProblemError)
-  implicit def problemFormat: RootJsonFormat[Problem]                           = jsonFormat5(Problem)
+  implicit def purposeFormat: RootJsonFormat[Purpose]                               = jsonFormat13(Purpose)
+  implicit def purposeVersionFormat: RootJsonFormat[PurposeVersion]                 = jsonFormat8(PurposeVersion)
+  implicit def purposesFormat: RootJsonFormat[Purposes]                             = jsonFormat1(Purposes)
+  implicit def purposeSeedFormat: RootJsonFormat[PurposeSeed]                       = jsonFormat5(PurposeSeed)
+  implicit def purposeUpdateContentFormat: RootJsonFormat[PurposeUpdateContent]     = jsonFormat3(PurposeUpdateContent)
+  implicit def purposeVersionSeedFormat: RootJsonFormat[PurposeVersionSeed]         = jsonFormat1(PurposeVersionSeed)
+  implicit def problemErrorFormat: RootJsonFormat[ProblemError]                     = jsonFormat2(ProblemError)
+  implicit def problemFormat: RootJsonFormat[Problem]                               = jsonFormat5(Problem)
   implicit def waitingForApprovalPurposeVersionUpdateFormat
     : RootJsonFormat[WaitingForApprovalPurposeVersionUpdateContent] = jsonFormat1(
     WaitingForApprovalPurposeVersionUpdateContent

--- a/src/main/scala/it/pagopa/interop/purposeprocess/error/RiskAnalysisTemplateErrors.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/error/RiskAnalysisTemplateErrors.scala
@@ -16,8 +16,6 @@ object RiskAnalysisTemplateErrors {
   final case class QuestionNotFoundInConfig(questionId: String, configVersion: String)
       extends Throwable(s"Question $questionId not found in configuration with version $configVersion")
 
-  /////
-
   final case class UnexpectedQuestionType(questionType: String)
       extends Throwable(s"Unexpected question type in template: $questionType")
 

--- a/src/main/scala/it/pagopa/interop/purposeprocess/error/RiskAnalysisTemplateErrors.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/error/RiskAnalysisTemplateErrors.scala
@@ -16,4 +16,9 @@ object RiskAnalysisTemplateErrors {
   final case class QuestionNotFoundInConfig(questionId: String, configVersion: String)
       extends Throwable(s"Question $questionId not found in configuration with version $configVersion")
 
+  /////
+
+  final case class UnexpectedQuestionType(questionType: String)
+      extends Throwable(s"Unexpected question type in template: $questionType")
+
 }

--- a/src/main/scala/it/pagopa/interop/purposeprocess/error/RiskAnalysisValidationError.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/error/RiskAnalysisValidationError.scala
@@ -23,10 +23,17 @@ final case class TooManyOccurrences(fieldName: String)                         e
 final case class MissingExpectedField(fieldName: String)                       extends RiskAnalysisValidationError {
   val message: String = s"Expected field $fieldName not found in form"
 }
-final case class UnexpectedFieldValue(fieldName: String, dependentField: String, expectedValue: String)
+final case class UnexpectedFieldValueByDependency(fieldName: String, dependentField: String, expectedValue: String)
     extends RiskAnalysisValidationError {
   val message: String = s"Field $dependentField requires field $fieldName value to be $expectedValue"
 }
+final case class UnexpectedFieldValue(fieldName: String, allowedValues: Option[Set[String]])
+    extends RiskAnalysisValidationError {
+  val message: String = s"Field $fieldName should be one of ${allowedValues.fold("empty")(_.mkString("[", ",", "]"))}"
+}
 final case class UnexpectedFieldFormat(fieldName: String)                      extends RiskAnalysisValidationError {
   val message: String = s"Unexpected format for field $fieldName"
+}
+final case class UnexpectedTemplateVersion(templateVersion: String)            extends RiskAnalysisValidationError {
+  val message: String = s"Unexpected template version $templateVersion"
 }

--- a/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisRules/DependencyEntry.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisRules/DependencyEntry.scala
@@ -1,0 +1,3 @@
+package it.pagopa.interop.purposeprocess.model.riskAnalysisRules
+
+final case class DependencyEntry(fieldName: String, fieldValue: String)

--- a/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisRules/ValidationEntry.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisRules/ValidationEntry.scala
@@ -1,0 +1,11 @@
+package it.pagopa.interop.purposeprocess.model.riskAnalysisRules
+
+import it.pagopa.interop.purposeprocess.model.riskAnalysisTemplate.DataType
+
+final case class ValidationEntry(
+  fieldName: String,
+  dataType: DataType,
+  required: Boolean,
+  dependencies: Seq[DependencyEntry],
+  allowedValues: Option[Set[String]]
+)

--- a/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisTemplate/DataType.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisTemplate/DataType.scala
@@ -1,0 +1,29 @@
+package it.pagopa.interop.purposeprocess.model.riskAnalysisTemplate
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import spray.json.{DefaultJsonProtocol, JsString, JsValue, RootJsonFormat, deserializationError}
+
+sealed trait DataType
+object Single   extends DataType
+object Multi    extends DataType
+object FreeText extends DataType
+
+object DataType extends DefaultJsonProtocol with SprayJsonSupport {
+  implicit object EServiceDescriptorStateFormat extends RootJsonFormat[DataType] {
+    def write(obj: DataType): JsValue =
+      obj match {
+        case Single   => JsString("single")
+        case Multi    => JsString("multi")
+        case FreeText => JsString("freeText")
+      }
+
+    def read(json: JsValue): DataType =
+      json match {
+        case JsString("single")   => Single
+        case JsString("multi")    => Multi
+        case JsString("freeText") => FreeText
+        case unrecognized         =>
+          deserializationError(s"DataType serialization error ${unrecognized.toString}")
+      }
+  }
+}

--- a/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisTemplate/FormConfigQuestion.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisTemplate/FormConfigQuestion.scala
@@ -8,7 +8,7 @@ sealed trait FormConfigQuestion {
   def id: String
   def pdfLabel: LocalizedText
   def pdfInfoLabel: Option[LocalizedText]
-  def dataType: String
+  def dataType: DataType
   def required: Boolean
   def dependencies: List[Dependency]
 }
@@ -37,7 +37,7 @@ final case class FreeInputQuestion(
   id: String,
   pdfLabel: LocalizedText,
   pdfInfoLabel: Option[LocalizedText],
-  dataType: String,
+  dataType: DataType,
   required: Boolean,
   dependencies: List[Dependency]
 ) extends FormConfigQuestion
@@ -50,7 +50,7 @@ final case class SingleQuestion(
   id: String,
   pdfLabel: LocalizedText,
   pdfInfoLabel: Option[LocalizedText],
-  dataType: String,
+  dataType: DataType,
   options: List[LabeledValue],
   required: Boolean,
   dependencies: List[Dependency]
@@ -64,7 +64,7 @@ final case class MultiQuestion(
   id: String,
   pdfLabel: LocalizedText,
   pdfInfoLabel: Option[LocalizedText],
-  dataType: String,
+  dataType: DataType,
   options: List[LabeledValue],
   required: Boolean,
   dependencies: List[Dependency]

--- a/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisTemplate/FormConfigQuestion.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisTemplate/FormConfigQuestion.scala
@@ -1,13 +1,16 @@
 package it.pagopa.interop.purposeprocess.model.riskAnalysisTemplate
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import it.pagopa.interop.purposeprocess.error.RiskAnalysisTemplateErrors.UnexpectedQuestionType
 import spray.json._
 
 sealed trait FormConfigQuestion {
   def id: String
-  def label: LocalizedText
-  def infoLabel: Option[LocalizedText]
-  def `type`: String
+  def pdfLabel: LocalizedText
+  def pdfInfoLabel: Option[LocalizedText]
+  def dataType: String
+  def required: Boolean
+  def dependencies: List[Dependency]
 }
 
 sealed trait SingleAnswerQuestionConfig extends FormConfigQuestion
@@ -17,50 +20,59 @@ object FormConfigQuestion extends DefaultJsonProtocol with SprayJsonSupport {
   implicit object FormConfigQuestionJsonFormat extends RootJsonFormat[FormConfigQuestion] {
     def write(a: FormConfigQuestion): JsValue = a match {
       case q: FreeInputQuestion => q.toJson
-      case q: CheckboxQuestion  => q.toJson
-      case q: RadioQuestion     => q.toJson
+      case q: SingleQuestion    => q.toJson
+      case q: MultiQuestion     => q.toJson
     }
 
     def read(value: JsValue): FormConfigQuestion =
-      value.asJsObject.fields("type") match {
-        case JsString("text")       => value.convertTo[FreeInputQuestion]
-        case JsString("checkbox")   => value.convertTo[CheckboxQuestion]
-        case JsString("radio")      => value.convertTo[RadioQuestion]
-        case JsString("select-one") => value.convertTo[RadioQuestion] // This has the same behaviour of radio
-        case v                      => throw new RuntimeException(s"Failed to decode $v")
+      value.asJsObject.fields("dataType") match {
+        case JsString("freeText") => value.convertTo[FreeInputQuestion]
+        case JsString("multi")    => value.convertTo[MultiQuestion]
+        case JsString("single")   => value.convertTo[SingleQuestion]
+        case other                => throw UnexpectedQuestionType(other.compactPrint)
       }
   }
 
   implicit val format: RootJsonFormat[FormConfigQuestion] = FormConfigQuestionJsonFormat
 }
 
-final case class FreeInputQuestion(id: String, label: LocalizedText, infoLabel: Option[LocalizedText], `type`: String)
-    extends SingleAnswerQuestionConfig
-
-object FreeInputQuestion extends DefaultJsonProtocol with SprayJsonSupport {
-  implicit def format: RootJsonFormat[FreeInputQuestion] = jsonFormat4(FreeInputQuestion.apply)
-}
-
-final case class RadioQuestion(
+final case class FreeInputQuestion(
   id: String,
-  label: LocalizedText,
-  infoLabel: Option[LocalizedText],
-  `type`: String,
-  options: Seq[LabeledValue]
+  pdfLabel: LocalizedText,
+  pdfInfoLabel: Option[LocalizedText],
+  dataType: String,
+  required: Boolean,
+  dependencies: List[Dependency]
 ) extends SingleAnswerQuestionConfig
 
-object RadioQuestion extends DefaultJsonProtocol with SprayJsonSupport {
-  implicit def format: RootJsonFormat[RadioQuestion] = jsonFormat5(RadioQuestion.apply)
+object FreeInputQuestion extends DefaultJsonProtocol with SprayJsonSupport {
+  implicit def format: RootJsonFormat[FreeInputQuestion] = jsonFormat6(FreeInputQuestion.apply)
 }
 
-final case class CheckboxQuestion(
+final case class SingleQuestion(
   id: String,
-  label: LocalizedText,
-  infoLabel: Option[LocalizedText],
-  `type`: String,
-  options: Seq[LabeledValue]
+  pdfLabel: LocalizedText,
+  pdfInfoLabel: Option[LocalizedText],
+  dataType: String,
+  options: List[LabeledValue],
+  required: Boolean,
+  dependencies: List[Dependency]
+) extends SingleAnswerQuestionConfig
+
+object SingleQuestion extends DefaultJsonProtocol with SprayJsonSupport {
+  implicit def format: RootJsonFormat[SingleQuestion] = jsonFormat7(SingleQuestion.apply)
+}
+
+final case class MultiQuestion(
+  id: String,
+  pdfLabel: LocalizedText,
+  pdfInfoLabel: Option[LocalizedText],
+  dataType: String,
+  options: List[LabeledValue],
+  required: Boolean,
+  dependencies: List[Dependency]
 ) extends MultiAnswerQuestionConfig
 
-object CheckboxQuestion extends DefaultJsonProtocol with SprayJsonSupport {
-  implicit def format: RootJsonFormat[CheckboxQuestion] = jsonFormat5(CheckboxQuestion.apply)
+object MultiQuestion extends DefaultJsonProtocol with SprayJsonSupport {
+  implicit def format: RootJsonFormat[MultiQuestion] = jsonFormat7(MultiQuestion.apply)
 }

--- a/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisTemplate/FormConfigQuestion.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisTemplate/FormConfigQuestion.scala
@@ -13,9 +13,6 @@ sealed trait FormConfigQuestion {
   def dependencies: List[Dependency]
 }
 
-sealed trait SingleAnswerQuestionConfig extends FormConfigQuestion
-sealed trait MultiAnswerQuestionConfig  extends FormConfigQuestion
-
 object FormConfigQuestion extends DefaultJsonProtocol with SprayJsonSupport {
   implicit object FormConfigQuestionJsonFormat extends RootJsonFormat[FormConfigQuestion] {
     def write(a: FormConfigQuestion): JsValue = a match {
@@ -43,7 +40,7 @@ final case class FreeInputQuestion(
   dataType: String,
   required: Boolean,
   dependencies: List[Dependency]
-) extends SingleAnswerQuestionConfig
+) extends FormConfigQuestion
 
 object FreeInputQuestion extends DefaultJsonProtocol with SprayJsonSupport {
   implicit def format: RootJsonFormat[FreeInputQuestion] = jsonFormat6(FreeInputQuestion.apply)
@@ -57,7 +54,7 @@ final case class SingleQuestion(
   options: List[LabeledValue],
   required: Boolean,
   dependencies: List[Dependency]
-) extends SingleAnswerQuestionConfig
+) extends FormConfigQuestion
 
 object SingleQuestion extends DefaultJsonProtocol with SprayJsonSupport {
   implicit def format: RootJsonFormat[SingleQuestion] = jsonFormat7(SingleQuestion.apply)
@@ -71,7 +68,7 @@ final case class MultiQuestion(
   options: List[LabeledValue],
   required: Boolean,
   dependencies: List[Dependency]
-) extends MultiAnswerQuestionConfig
+) extends FormConfigQuestion
 
 object MultiQuestion extends DefaultJsonProtocol with SprayJsonSupport {
   implicit def format: RootJsonFormat[MultiQuestion] = jsonFormat7(MultiQuestion.apply)

--- a/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisTemplate/LabeledValue.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/model/riskAnalysisTemplate/LabeledValue.scala
@@ -3,7 +3,7 @@ package it.pagopa.interop.purposeprocess.model.riskAnalysisTemplate
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import spray.json._
 
-final case class LabeledValue(label: LocalizedText, value: String)
+final case class LabeledValue(pdfLabel: LocalizedText, value: String)
 
 object LabeledValue extends DefaultJsonProtocol with SprayJsonSupport {
   implicit def format: RootJsonFormat[LabeledValue] = jsonFormat2(LabeledValue.apply)

--- a/src/main/scala/it/pagopa/interop/purposeprocess/service/RiskAnalysisService.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/service/RiskAnalysisService.scala
@@ -1,0 +1,24 @@
+package it.pagopa.interop.purposeprocess.service
+
+import it.pagopa.interop.purposeprocess.model.riskAnalysisTemplate.RiskAnalysisFormConfig
+
+import scala.io.Source
+import spray.json._
+
+object RiskAnalysisService {
+
+  // The Map key must correspond to the version field of the risk analysis form
+  val riskAnalysisForms: Map[String, RiskAnalysisFormConfig] = Map(
+    "1.0" -> loadRiskAnalysisFormConfig("riskAnalysisTemplate/forms/1.0.json"),
+    "2.0" -> loadRiskAnalysisFormConfig("riskAnalysisTemplate/forms/2.0.json")
+  )
+
+  def loadRiskAnalysisFormConfig(resourcePath: String): RiskAnalysisFormConfig =
+    Source
+      .fromResource(resourcePath)
+      .getLines()
+      .mkString(System.lineSeparator())
+      .parseJson
+      .convertTo[RiskAnalysisFormConfig]
+
+}

--- a/src/test/resources/riskAnalysisTemplate/forms/test.json
+++ b/src/test/resources/riskAnalysisTemplate/forms/test.json
@@ -4,11 +4,20 @@
     {
       "id": "purpose",
       "type": "text",
+      "dataType": "freeText",
       "label": {
         "it": "Finalità (richiesto)",
         "en": "Purpose (required)"
       },
       "infoLabel": {
+        "it": "Indicare per quale finalità si intende accedere ai dati messi a disposizione con la fruizione del presente E-Service",
+        "en": "State what is your purpose in accessing the data provided with this E-Service"
+      },
+      "pdfLabel": {
+        "it": "Finalità (richiesto)",
+        "en": "Purpose (required)"
+      },
+      "pdfInfoLabel": {
         "it": "Indicare per quale finalità si intende accedere ai dati messi a disposizione con la fruizione del presente E-Service",
         "en": "State what is your purpose in accessing the data provided with this E-Service"
       },
@@ -19,17 +28,24 @@
     {
       "id": "usesPersonalData",
       "type": "radio",
+      "dataType": "single",
       "label": {
+        "it": "Indicare se si accede a dati personali (richiesto)",
+        "en": "Will you have access to personal data? (required)"
+      },
+      "pdfLabel": {
         "it": "Indicare se si accede a dati personali (richiesto)",
         "en": "Will you have access to personal data? (required)"
       },
       "options": [
         {
           "label": { "it": "Sì", "en": "Yes" },
+          "pdfLabel": { "it": "Sì", "en": "Yes" },
           "value": "YES"
         },
         {
           "label": { "it": "No", "en": "No" },
+          "pdfLabel": { "it": "No", "en": "No" },
           "value": "NO"
         }
       ],
@@ -40,13 +56,22 @@
     {
       "id": "legalBasis",
       "type": "checkbox",
+      "dataType": "multi",
       "label": {
+        "it": "Indicare sulla base di quale, fra le seguenti basi giuridiche ex art. 6 del GDPR, ritiene di essere titolato ad accedere ai dati personali messi a disposizione con la fruizione dell’E-Service (richiesto, scelta multipla)",
+        "en": "Based on GDPR ex art. 6, state on which legal basis you think you are entitled to access the personal data provided with the access to this E-Service (required, multiple choice)"
+      },
+      "pdfLabel": {
         "it": "Indicare sulla base di quale, fra le seguenti basi giuridiche ex art. 6 del GDPR, ritiene di essere titolato ad accedere ai dati personali messi a disposizione con la fruizione dell’E-Service (richiesto, scelta multipla)",
         "en": "Based on GDPR ex art. 6, state on which legal basis you think you are entitled to access the personal data provided with the access to this E-Service (required, multiple choice)"
       },
       "options": [
         {
           "label": {
+            "it": "consenso dell’interessato al trattamento dei dati personali per una o più specifiche finalità",
+            "en": "consent of the interested party to the treatment of personal data for one or more purposes"
+          },
+          "pdfLabel": {
             "it": "consenso dell’interessato al trattamento dei dati personali per una o più specifiche finalità",
             "en": "consent of the interested party to the treatment of personal data for one or more purposes"
           },
@@ -57,10 +82,18 @@
             "it": "esecuzione di un contratto di cui l'interessato è parte o di misure precontrattuali adottate su richiesta dello stesso",
             "en": "execution of a contract which the party is part of or precontractual measures adopted upon request of said party"
           },
+          "pdfLabel": {
+            "it": "esecuzione di un contratto di cui l'interessato è parte o di misure precontrattuali adottate su richiesta dello stesso",
+            "en": "execution of a contract which the party is part of or precontractual measures adopted upon request of said party"
+          },
           "value": "CONTRACT"
         },
         {
           "label": {
+            "it": "adempimento di un obbligo legale",
+            "en": "fulfillment of a legal obligation"
+          },
+          "pdfLabel": {
             "it": "adempimento di un obbligo legale",
             "en": "fulfillment of a legal obligation"
           },
@@ -71,6 +104,10 @@
             "it": "salvaguardia degli interessi vitali di una persona fisica",
             "en": "safeguard of vital interests of a physical person"
           },
+          "pdfLabel": {
+            "it": "salvaguardia degli interessi vitali di una persona fisica",
+            "en": "safeguard of vital interests of a physical person"
+          },
           "value": "SAFEGUARD"
         },
         {
@@ -78,10 +115,18 @@
             "it": "esecuzione di un compito di interesse pubblico o connesso all'esercizio di pubblici poteri di cui sei investito",
             "en": "execution of a task of public interest or connected to the exercise of public authority bestowed upon you"
           },
+          "pdfLabel": {
+            "it": "esecuzione di un compito di interesse pubblico o connesso all'esercizio di pubblici poteri di cui sei investito",
+            "en": "execution of a task of public interest or connected to the exercise of public authority bestowed upon you"
+          },
           "value": "PUBLIC_INTEREST"
         },
         {
           "label": {
+            "it": "perseguimento del legittimo interesse del titolare del trattamento o di terzi, a condizione che non prevalgano gli interessi o i diritti e le libertà fondamentali dell'interessato che richiedono la protezione dei dati personali, in particolare se l'interessato è un minore",
+            "en": "pursue of a legitimate interest of the owner of the treatment or of a third party, on condition that the interest, rights and fundamental freedoms of the interested party that require personal data protection not prevail, with particular interests in case of a minor"
+          },
+          "pdfLabel": {
             "it": "perseguimento del legittimo interesse del titolare del trattamento o di terzi, a condizione che non prevalgano gli interessi o i diritti e le libertà fondamentali dell'interessato che richiedono la protezione dei dati personali, in particolare se l'interessato è un minore",
             "en": "pursue of a legitimate interest of the owner of the treatment or of a third party, on condition that the interest, rights and fundamental freedoms of the interested party that require personal data protection not prevail, with particular interests in case of a minor"
           },
@@ -100,6 +145,7 @@
     {
       "id": "dataQuantity",
       "type": "select-one",
+      "dataType": "single",
       "label": {
         "it": "Fascia di riferimento (richiesto)",
         "en": "Reference range (required)"
@@ -108,25 +154,38 @@
         "it": "Si richiede di specificare la fascia di riferimento fra quelle di seguito indicate anche in funzione del periodo di validità del voucher emesso per la fruizione dell’E-Service",
         "en": "You are required to state the reference range among the options given, keeping in mind the expiration of the access token (voucher) emitted for the fruition of the E-Service"
       },
+      "pdfLabel": {
+        "it": "Fascia di riferimento (richiesto)",
+        "en": "Reference range (required)"
+      },
+      "pdfInfoLabel": {
+        "it": "Si richiede di specificare la fascia di riferimento fra quelle di seguito indicate anche in funzione del periodo di validità del voucher emesso per la fruizione dell’E-Service",
+        "en": "You are required to state the reference range among the options given, keeping in mind the expiration of the access token (voucher) emitted for the fruition of the E-Service"
+      },
       "options": [
         {
           "label": { "it": "0-100", "en": "0-100" },
+          "pdfLabel": { "it": "0-100", "en": "0-100" },
           "value": "QUANTITY_0_TO_100"
         },
         {
           "label": { "it": "101-500", "en": "101-500" },
+          "pdfLabel": { "it": "101-500", "en": "101-500" },
           "value": "QUANTITY_101_TO_500"
         },
         {
           "label": { "it": "501-1000", "en": "501-1000" },
+          "pdfLabel": { "it": "501-1000", "en": "501-1000" },
           "value": "QUANTITY_500_TO_1000"
         },
         {
           "label": { "it": "1001-5000", "en": "1001-5000" },
+          "pdfLabel": { "it": "1001-5000", "en": "1001-5000" },
           "value": "QUANTITY_1001_TO_5000"
         },
         {
           "label": { "it": "da 5001 in su", "en": "5001 and above" },
+          "pdfLabel": { "it": "da 5001 in su", "en": "5001 and above" },
           "value": "QUANTITY_5001_OVER"
         }
       ],

--- a/src/test/scala/it/pagopa/interop/purposeprocess/PDFCreatorSpec.scala
+++ b/src/test/scala/it/pagopa/interop/purposeprocess/PDFCreatorSpec.scala
@@ -172,10 +172,10 @@ object PDFCreatorSpec {
             case _: FreeInputQuestion =>
               expectedAnswer.size shouldBe 1
               answers should include(expectedAnswer.head)
-            case q: RadioQuestion     =>
+            case q: SingleQuestion    =>
               expectedAnswer.size shouldBe 1
               answers should include(q.options.find(_.value == expectedAnswer.head).map(getValue).get)
-            case q: CheckboxQuestion  =>
+            case q: MultiQuestion     =>
               answers should expectedAnswer
                 .map(a => include(q.options.find(_.value == a).map(getValue).get))
                 .reduce(_ and _)
@@ -183,13 +183,13 @@ object PDFCreatorSpec {
 
         language match {
           case LanguageIt =>
-            answers should include(expectedQuestion.label.it)
-            expectedQuestion.infoLabel.fold(succeed)(l => answers should include(l.it))
-            checkAnswer(_.label.it)
+            answers should include(expectedQuestion.pdfLabel.it)
+            expectedQuestion.pdfInfoLabel.fold(succeed)(l => answers should include(l.it))
+            checkAnswer(_.pdfLabel.it)
           case LanguageEn =>
-            answers should include(expectedQuestion.label.en)
-            expectedQuestion.infoLabel.fold(succeed)(l => answers should include(l.en))
-            checkAnswer(_.label.en)
+            answers should include(expectedQuestion.pdfLabel.en)
+            expectedQuestion.pdfInfoLabel.fold(succeed)(l => answers should include(l.en))
+            checkAnswer(_.pdfLabel.en)
         }
 
       case Failure(exception) => fail(exception)

--- a/src/test/scala/it/pagopa/interop/purposeprocess/PDFCreatorSpec.scala
+++ b/src/test/scala/it/pagopa/interop/purposeprocess/PDFCreatorSpec.scala
@@ -7,26 +7,26 @@ import it.pagopa.interop.purposemanagement.client.model.{
 }
 import it.pagopa.interop.purposeprocess.error.RiskAnalysisTemplateErrors._
 import it.pagopa.interop.purposeprocess.model.riskAnalysisTemplate._
+import it.pagopa.interop.purposeprocess.service.RiskAnalysisService
 import it.pagopa.interop.purposeprocess.service.impl.PDFCreatorImpl.setupData
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpecLike
-import spray.json._
 
 import java.util.UUID
-import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 class PDFCreatorSpec extends AnyWordSpecLike with SpecHelper {
 
   import PDFCreatorSpec._
 
-  val testConfig: RiskAnalysisFormConfig = loadRiskAnalysisFormConfig("riskAnalysisTemplate/forms/test.json")
+  val testConfig: RiskAnalysisFormConfig =
+    RiskAnalysisService.loadRiskAnalysisFormConfig("riskAnalysisTemplate/forms/test.json")
 
   val languages = List(LanguageIt, LanguageEn)
 
   "Risk Analysis PDF creation" should {
-    "succeed for 'text' type config" in {
+    "succeed for 'freeText' type config" in {
       val questionKey      = "purpose"
       val answer           = "My Purpose"
       val riskAnalysisForm = makeSingleAnswerForm(key = questionKey, value = answer)
@@ -41,7 +41,7 @@ class PDFCreatorSpec extends AnyWordSpecLike with SpecHelper {
       )
     }
 
-    "succeed for 'radio' type config" in {
+    "succeed for 'single' type config" in {
       val questionKey      = "usesPersonalData"
       val answer           = "YES"
       val riskAnalysisForm = makeSingleAnswerForm(key = questionKey, value = answer)
@@ -56,7 +56,7 @@ class PDFCreatorSpec extends AnyWordSpecLike with SpecHelper {
       )
     }
 
-    "succeed for 'checkbox' type config" in {
+    "succeed for 'multi' type config" in {
       val questionKey      = "legalBasis"
       val answers          = List("CONSENT", "CONTRACT", "SAFEGUARD")
       val riskAnalysisForm = makeMultiAnswerForm(key = questionKey, values = answers)
@@ -66,21 +66,6 @@ class PDFCreatorSpec extends AnyWordSpecLike with SpecHelper {
           result = setupData(testConfig, riskAnalysisForm, dailyCalls, eServiceInfo, language),
           expectedQuestion = testConfig.questions.find(_.id == questionKey).get,
           expectedAnswer = answers,
-          language = language
-        )
-      )
-    }
-
-    "succeed for 'select-one' type config" in {
-      val questionKey      = "dataQuantity"
-      val answer           = "QUANTITY_0_TO_100"
-      val riskAnalysisForm = makeSingleAnswerForm(key = questionKey, value = answer)
-
-      languages.foreach(language =>
-        checkSuccessfulSingleAnswerResult(
-          result = setupData(testConfig, riskAnalysisForm, dailyCalls, eServiceInfo, language),
-          expectedQuestion = testConfig.questions.find(_.id == questionKey).get,
-          expectedAnswer = answer,
           language = language
         )
       )
@@ -195,11 +180,4 @@ object PDFCreatorSpec {
       case Failure(exception) => fail(exception)
     }
 
-  def loadRiskAnalysisFormConfig(resourcePath: String): RiskAnalysisFormConfig =
-    Source
-      .fromResource(resourcePath)
-      .getLines()
-      .mkString(System.lineSeparator())
-      .parseJson
-      .convertTo[RiskAnalysisFormConfig]
 }

--- a/src/test/scala/it/pagopa/interop/purposeprocess/PurposeApiServiceSpec.scala
+++ b/src/test/scala/it/pagopa/interop/purposeprocess/PurposeApiServiceSpec.scala
@@ -93,7 +93,7 @@ class PurposeApiServiceSpec extends AnyWordSpecLike with SpecHelper with Scalate
         consumerId = consumerId,
         title = "A title",
         description = "A description",
-        riskAnalysisForm = Some(SpecData.validRiskAnalysis)
+        riskAnalysisForm = Some(SpecData.validRiskAnalysis1_0)
       )
 
       val managementResponse = PurposeManagementDependency.Purpose(

--- a/src/test/scala/it/pagopa/interop/purposeprocess/PurposeApiServiceSpec.scala
+++ b/src/test/scala/it/pagopa/interop/purposeprocess/PurposeApiServiceSpec.scala
@@ -135,10 +135,11 @@ class PurposeApiServiceSpec extends AnyWordSpecLike with SpecHelper with Scalate
       implicit val context: Seq[(String, String)] =
         Seq("bearer" -> bearerToken, USER_ROLES -> "admin", UID -> userId.toString)
 
-      val incorrectRiskAnalysis = RiskAnalysisForm(
-        version = "1.0",
-        answers = RiskAnalysisFormAnswers(purpose = "purpose", usesPersonalData = RiskAnalysisFormYesNoAnswer.YES)
-      )
+      val incorrectRiskAnalysis =
+        RiskAnalysisForm(
+          version = "1.0",
+          answers = Map("purpose" -> List("purpose"), "usesPersonalData" -> List("YES"))
+        )
 
       val seed: PurposeSeed = PurposeSeed(
         eserviceId = eServiceId,

--- a/src/test/scala/it/pagopa/interop/purposeprocess/RiskAnalysisValidationSpec.scala
+++ b/src/test/scala/it/pagopa/interop/purposeprocess/RiskAnalysisValidationSpec.scala
@@ -21,15 +21,15 @@ class RiskAnalysisValidationSpec extends AnyWordSpecLike {
 
   "Risk Analysis Validation" should {
     "succeed on correct form 1.0" in {
-      val riskAnalysis = SpecData.validRiskAnalysis
+      val riskAnalysis = SpecData.validRiskAnalysis1_0
 
       val expected = RiskAnalysisFormSeed(
         version = riskAnalysis.version,
         singleAnswers = Seq(
-          SingleAnswerSeed("purpose", riskAnalysis.answers("purpose").head.some),
+          SingleAnswerSeed("purpose", "MyPurpose".some),
           SingleAnswerSeed("usesPersonalData", Some("YES")),
-          SingleAnswerSeed("legalObligationReference", riskAnalysis.answers("legalObligationReference").head.some),
-          SingleAnswerSeed("publicInterestReference", riskAnalysis.answers("publicInterestReference").head.some),
+          SingleAnswerSeed("legalObligationReference", "somethingLegal".some),
+          SingleAnswerSeed("publicInterestReference", "somethingPublic".some),
           SingleAnswerSeed("knowsAccessedDataCategories", Some("YES")),
           SingleAnswerSeed("accessDataArt9Gdpr", Some("NO")),
           SingleAnswerSeed("accessUnderageData", Some("NO")),
@@ -52,33 +52,38 @@ class RiskAnalysisValidationSpec extends AnyWordSpecLike {
     }
 
     "succeed on correct form 2.0" in {
-//      val riskAnalysis = SpecData.validRiskAnalysis
-//
-//      val expected = RiskAnalysisFormSeed(
-//        version = riskAnalysis.version,
-//        singleAnswers = Seq(
-//          SingleAnswerSeed("purpose", Some(riskAnalysis.answers.purpose)),
-//          SingleAnswerSeed("usesPersonalData", Some("YES")),
-//          SingleAnswerSeed("legalObligationReference", riskAnalysis.answers.legalObligationReference),
-//          SingleAnswerSeed("publicInterestReference", riskAnalysis.answers.publicInterestReference),
-//          SingleAnswerSeed("knowsAccessedDataCategories", Some("YES")),
-//          SingleAnswerSeed("accessDataArt9Gdpr", Some("NO")),
-//          SingleAnswerSeed("accessUnderageData", Some("NO")),
-//          SingleAnswerSeed("knowsDataQuantity", Some("NO")),
-//          SingleAnswerSeed("deliveryMethod", Some("ANONYMOUS")),
-//          SingleAnswerSeed("doneDpia", Some("NO")),
-//          SingleAnswerSeed("definedDataRetentionPeriod", Some("NO")),
-//          SingleAnswerSeed("purposePursuit", Some("MERE_CORRECTNESS"))
-//        ),
-//        multiAnswers = Seq(
-//          MultiAnswerSeed("legalBasis", Seq("LEGAL_OBLIGATION", "PUBLIC_INTEREST")),
-//          MultiAnswerSeed("checkedExistenceMereCorrectnessInteropCatalogue", Seq("YES"))
-//        )
-//      )
-//
-//      val result: ValidationResult[RiskAnalysisFormSeed] = RiskAnalysisValidation.validate(riskAnalysis)
-//
-//      verifyValidationFormResult(result, expected)
+      val riskAnalysis = SpecData.validRiskAnalysis2_0
+
+      val expected = RiskAnalysisFormSeed(
+        version = riskAnalysis.version,
+        singleAnswers = Seq(
+          SingleAnswerSeed("purpose", "INSTITUTIONAL".some),
+          SingleAnswerSeed("institutionalPurpose", "MyPurpose".some),
+          SingleAnswerSeed("otherPersonalDataTypes", "MyDataTypes".some),
+          SingleAnswerSeed("legalObligationReference", "somethingLegal".some),
+          SingleAnswerSeed("legalBasisPublicInterest", "RULE_OF_LAW".some),
+          SingleAnswerSeed("ruleOfLawText", "TheLaw".some),
+          SingleAnswerSeed("knowsDataQuantity", "NO".some),
+          SingleAnswerSeed("deliveryMethod", "ANONYMOUS".some),
+          SingleAnswerSeed("policyProvided", "NO".some),
+          SingleAnswerSeed("confirmPricipleIntegrityAndDiscretion", "true".some),
+          SingleAnswerSeed("reasonPolicyNotProvided", "Because".some),
+          SingleAnswerSeed("doneDpia", "NO".some),
+          SingleAnswerSeed("dataRetentionPeriod", "true".some),
+          SingleAnswerSeed("purposePursuit", "MERE_CORRECTNESS".some),
+          SingleAnswerSeed("checkedExistenceMereCorrectnessInteropCatalogue", "true".some),
+          SingleAnswerSeed("usesThirdPartyData", "NO".some),
+          SingleAnswerSeed("declarationConfirmGDPR", "true".some)
+        ),
+        multiAnswers = Seq(
+          MultiAnswerSeed("personalDataTypes", Seq("OTHER")),
+          MultiAnswerSeed("legalBasis", Seq("LEGAL_OBLIGATION", "PUBLIC_INTEREST"))
+        )
+      )
+
+      val result: ValidationResult[RiskAnalysisFormSeed] = RiskAnalysisValidation.validate(riskAnalysis)
+
+      verifyValidationFormResult(result, expected)
 
     }
 

--- a/src/test/scala/it/pagopa/interop/purposeprocess/SpecData.scala
+++ b/src/test/scala/it/pagopa/interop/purposeprocess/SpecData.scala
@@ -71,10 +71,10 @@ object SpecData {
       )
     )
 
-  val validRiskAnalysis: RiskAnalysisForm = RiskAnalysisForm(
+  val validRiskAnalysis1_0: RiskAnalysisForm = RiskAnalysisForm(
     version = "1.0",
     answers = Map(
-      "purpose"                                         -> List("purpose"),
+      "purpose"                                         -> List("MyPurpose"),
       "usesPersonalData"                                -> List("YES"),
       "usesThirdPartyPersonalData"                      -> Nil,
       "usesConfidentialData"                            -> Nil,
@@ -97,8 +97,34 @@ object SpecData {
     )
   )
 
+  val validRiskAnalysis2_0: RiskAnalysisForm = RiskAnalysisForm(
+    version = "2.0",
+    answers = Map(
+      "purpose"                                         -> List("INSTITUTIONAL"),
+      "institutionalPurpose"                            -> List("MyPurpose"),
+      "personalDataTypes"                               -> List("OTHER"),
+      "otherPersonalDataTypes"                          -> List("MyDataTypes"),
+      "legalBasis"                                      -> List("LEGAL_OBLIGATION", "PUBLIC_INTEREST"),
+      "legalObligationReference"                        -> List("somethingLegal"),
+      "legalBasisPublicInterest"                        -> List("RULE_OF_LAW"),
+      "ruleOfLawText"                                   -> List("TheLaw"),
+      "knowsDataQuantity"                               -> List("NO"),
+      "dataQuantity"                                    -> Nil,
+      "deliveryMethod"                                  -> List("ANONYMOUS"),
+      "policyProvided"                                  -> List("NO"),
+      "confirmPricipleIntegrityAndDiscretion"           -> List("true"),
+      "reasonPolicyNotProvided"                         -> List("Because"),
+      "doneDpia"                                        -> List("NO"),
+      "dataRetentionPeriod"                             -> List("true"),
+      "purposePursuit"                                  -> List("MERE_CORRECTNESS"),
+      "checkedExistenceMereCorrectnessInteropCatalogue" -> List("true"),
+      "usesThirdPartyData"                              -> List("NO"),
+      "declarationConfirmGDPR"                          -> List("true")
+    )
+  )
+
   val validManagementRiskAnalysisSeed: PurposeManagement.RiskAnalysisFormSeed =
-    RiskAnalysisValidation.validate(validRiskAnalysis).toOption.get
+    RiskAnalysisValidation.validate(validRiskAnalysis1_0).toOption.get
 
   val validManagementRiskAnalysis: PurposeManagement.RiskAnalysisForm =
     PurposeManagement.RiskAnalysisForm(

--- a/src/test/scala/it/pagopa/interop/purposeprocess/SpecData.scala
+++ b/src/test/scala/it/pagopa/interop/purposeprocess/SpecData.scala
@@ -73,27 +73,27 @@ object SpecData {
 
   val validRiskAnalysis: RiskAnalysisForm = RiskAnalysisForm(
     version = "1.0",
-    answers = RiskAnalysisFormAnswers(
-      purpose = "purpose",
-      usesPersonalData = RiskAnalysisFormYesNoAnswer.YES,
-      usesThirdPartyPersonalData = None,
-      usesConfidentialData = None,
-      securedDataAccess = None,
-      legalBasis = Some(Seq(FormLegalBasisAnswers.LEGAL_OBLIGATION, FormLegalBasisAnswers.PUBLIC_INTEREST)),
-      legalObligationReference = Some("something"),
-      publicInterestReference = Some("something"),
-      knowsAccessedDataCategories = Some(RiskAnalysisFormYesNoAnswer.YES),
-      accessDataArt9Gdpr = Some(RiskAnalysisFormYesNoAnswer.NO),
-      accessUnderageData = Some(RiskAnalysisFormYesNoAnswer.NO),
-      knowsDataQuantity = Some(RiskAnalysisFormYesNoAnswer.NO),
-      dataQuantity = None,
-      deliveryMethod = Some(FormDeliveryMethodAnswers.ANONYMOUS),
-      doneDpia = Some(RiskAnalysisFormYesNoAnswer.NO),
-      definedDataRetentionPeriod = Some(RiskAnalysisFormYesNoAnswer.NO),
-      purposePursuit = Some(FormPurposePursuitAnswers.MERE_CORRECTNESS),
-      checkedExistenceMereCorrectnessInteropCatalogue = Some(Seq(RiskAnalysisFormYesAnswer.YES)),
-      checkedAllDataNeeded = None,
-      checkedExistenceMinimalDataInteropCatalogue = None
+    answers = Map(
+      "purpose"                                         -> List("purpose"),
+      "usesPersonalData"                                -> List("YES"),
+      "usesThirdPartyPersonalData"                      -> Nil,
+      "usesConfidentialData"                            -> Nil,
+      "securedDataAccess"                               -> Nil,
+      "legalBasis"                                      -> List("LEGAL_OBLIGATION", "PUBLIC_INTEREST"),
+      "legalObligationReference"                        -> List("somethingLegal"),
+      "publicInterestReference"                         -> List("somethingPublic"),
+      "knowsAccessedDataCategories"                     -> List("YES"),
+      "accessDataArt9Gdpr"                              -> List("NO"),
+      "accessUnderageData"                              -> List("NO"),
+      "knowsDataQuantity"                               -> List("NO"),
+      "dataQuantity"                                    -> Nil,
+      "deliveryMethod"                                  -> List("ANONYMOUS"),
+      "doneDpia"                                        -> List("NO"),
+      "definedDataRetentionPeriod"                      -> List("NO"),
+      "purposePursuit"                                  -> List("MERE_CORRECTNESS"),
+      "checkedExistenceMereCorrectnessInteropCatalogue" -> List("YES"),
+      "checkedAllDataNeeded"                            -> Nil,
+      "checkedExistenceMinimalDataInteropCatalogue"     -> Nil
     )
   )
 


### PR DESCRIPTION
Major changes:
- dropped risk analysis type definition in openapi in favour of generic `Map[String, List[String]]` to support different forms versions
- data validation of form responses based on json configurations
- risk analysis validation rules are now automatically derived from json configs

Open points:
- pdf labels for boh v1 and v2 are yet to be defined