### PR TITLE
PIN-4722: Refactor get purposes to avoid DocumentDB memory error

### DIFF
--- a/src/main/scala/it/pagopa/interop/purposeprocess/common/readmodel/ReadModelId.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/common/readmodel/ReadModelId.scala
@@ -1,0 +1,10 @@
+package it.pagopa.interop.purposeprocess.common.readmodel
+
+import spray.json.DefaultJsonProtocol._
+import spray.json.RootJsonFormat
+
+final case class ReadModelId(id: String)
+
+object ReadModelId {
+  implicit val rmiFormat: RootJsonFormat[ReadModelId] = jsonFormat1(ReadModelId.apply)
+}

--- a/src/main/scala/it/pagopa/interop/purposeprocess/common/readmodel/ReadModelId.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/common/readmodel/ReadModelId.scala
@@ -1,9 +1,12 @@
 package it.pagopa.interop.purposeprocess.common.readmodel
 
+import it.pagopa.interop.commons.queue.message.Message.uuidFormat
 import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
 
-final case class ReadModelId(id: String)
+import java.util.UUID
+
+final case class ReadModelId(id: UUID)
 
 object ReadModelId {
   implicit val rmiFormat: RootJsonFormat[ReadModelId] = jsonFormat1(ReadModelId.apply)

--- a/src/main/scala/it/pagopa/interop/purposeprocess/common/readmodel/ReadModelPurposeQueries.scala
+++ b/src/main/scala/it/pagopa/interop/purposeprocess/common/readmodel/ReadModelPurposeQueries.scala
@@ -1,5 +1,7 @@
 package it.pagopa.interop.purposeprocess.common.readmodel
 
+import it.pagopa.interop.catalogmanagement.model.CatalogItem
+import it.pagopa.interop.catalogmanagement.model.persistence.JsonFormats.ciFormat
 import it.pagopa.interop.commons.cqrs.service.ReadModelService
 import it.pagopa.interop.purposemanagement.model.persistence.JsonFormats._
 import it.pagopa.interop.purposemanagement.model.purpose._
@@ -72,44 +74,42 @@ object ReadModelPurposeQueries extends ReadModelQuery {
       )
       // Using aggregate to perform case insensitive sorting
       //   N.B.: Required because DocumentDB does not support collation
-      purposes <- readModel.aggregate[PersistentPurpose](
+      purposes  <- readModel.aggregate[PersistentPurpose](
         "purposes",
         query ++
           Seq(
             addFields(Field("lowerName", Document("""{ "$toLower" : "$data.title" }"""))),
             sort(ascending("lowerName")),
-            // If requester is not Consumer or Producer, override the risk analysis form with null value
-            addFields(
-              Field(
-                "data.riskAnalysisForm",
-                Document(s"""{
-                            |  $$cond: {
-                            |    if: {
-                            |      $$or: [
-                            |        { $$eq: [ "$$data.consumerId", "${requesterId.toString}" ] },
-                            |        { $$eq: [ "$$eservice.data.producerId", "${requesterId.toString}" ] }
-                            |      ],
-                            |    },
-                            |    then: "$$data.riskAnalysisForm",
-                            |    else: null,
-                            |  },
-                            |}""".stripMargin)
-              )
-            ),
             project(fields(include("data")))
           ),
         offset = offset,
-        limit = limit
+        limit = limit,
+        allowDiskUse = true
       )
+      eservices <- purposesEservices(purposes, limit)
+
+      // If requester is not Consumer or Producer, override the risk analysis form with empty value
+      authorizedPurposes = purposes.map(p =>
+        Option
+          .when(p.consumerId == requesterId)(())
+          .orElse(
+            eservices
+              .find(pe => pe.id == p.eserviceId)
+              .filter(_.producerId == requesterId)
+              .map(_ => ())
+          )
+          .fold(p.copy(riskAnalysisForm = None))(_ => p)
+      )
+
       // Note: This could be obtained using $facet function (avoiding to execute the query twice),
       //   but it is not supported by DocumentDB
-      count    <- readModel.aggregate[TotalCountResult](
+      count <- readModel.aggregate[TotalCountResult](
         "purposes",
         query ++ Seq(count("totalCount"), project(computed("data", Document("""{ "totalCount" : "$totalCount" }""")))),
         offset = 0,
         limit = Int.MaxValue
       )
-    } yield PaginatedResult(results = purposes, totalCount = count.headOption.map(_.totalCount).getOrElse(0))
+    } yield PaginatedResult(results = authorizedPurposes, totalCount = count.headOption.map(_.totalCount).getOrElse(0))
   }
 
   private def listPurposesFilters(
@@ -161,22 +161,26 @@ object ReadModelPurposeQueries extends ReadModelQuery {
   private def producersEservicesFilter(
     producersIds: Seq[String]
   )(implicit ec: ExecutionContext, readModel: ReadModelService): Future[Bson] = {
+
     val producersEservicesIds: Future[Seq[ReadModelId]] =
-      if (producersIds.isEmpty) {
-        Future.successful(Seq.empty)
-      } else {
-        readModel.find[ReadModelId](
-          "eservices",
-          mapToVarArgs(producersIds.map(Filters.eq("data.producerId", _)))(Filters.or).getOrElse(Filters.empty()),
-          Projections.include("data.id"),
-          offset = 0,
-          limit = Int.MaxValue
+      mapToVarArgs(producersIds.map(Filters.eq("data.producerId", _)))(Filters.or)
+        .fold[Future[Seq[ReadModelId]]](Future.successful(Seq.empty))(filter =>
+          readModel
+            .find[ReadModelId]("eservices", filter, Projections.include("data.id"), offset = 0, limit = Int.MaxValue)
         )
-      }
 
     producersEservicesIds.map(ids =>
-      mapToVarArgs(ids.map(id => Filters.eq("data.eserviceId", id.id)))(Filters.or).getOrElse(Filters.empty())
+      mapToVarArgs(ids.map(id => Filters.eq("data.eserviceId", id.id.toString)))(Filters.or).getOrElse(Filters.empty())
     )
-
   }
+
+  private def purposesEservices(purposes: Seq[PersistentPurpose], limit: Int)(implicit
+    ec: ExecutionContext,
+    readModel: ReadModelService
+  ): Future[Seq[CatalogItem]] =
+    mapToVarArgs(purposes.map(p => Filters.eq("data.id", p.eserviceId.toString)))(Filters.or)
+      .fold[Future[Seq[CatalogItem]]](Future.successful(Seq.empty))(filter =>
+        readModel.find[CatalogItem]("eservices", filter, offset = 0, limit = limit)
+      )
+
 }


### PR DESCRIPTION
The query often causes memory limit errors on DocumentDB.
This PR make the query easier by
- removing the lookup on another collection
- adding 2 more queries that are easier (just `find` with filters)